### PR TITLE
feat: support full foreground sync

### DIFF
--- a/grimmory.koplugin/grimmory/executor.lua
+++ b/grimmory.koplugin/grimmory/executor.lua
@@ -209,6 +209,8 @@ function GrimmoryExecutor:run(runnable, on_progress)
                 break
             end
 
+            pcall(on_progress, nil, terminate)
+
             local continue_func = function() coroutine.resume(running_coroutine) end
             UIManager:scheduleIn(0.1, continue_func)
 

--- a/grimmory.koplugin/grimmory/ui/dialog_manager.lua
+++ b/grimmory.koplugin/grimmory/ui/dialog_manager.lua
@@ -360,6 +360,45 @@ function DialogManager:showPluginUpdater()
     end)
 end
 
+function DialogManager:showProgressDialog(title, dismiss_callback)
+    local dialog
+
+    if dismiss_callback ~= nil then
+        dismiss_callback = function()
+            local confirm_dialog = ConfirmBox:new({
+                text = _("Cancel Synchronization?"),
+                ok_callback = function()
+                    pcall(dismiss_callback)
+                    UIManager:close(dialog)
+                end,
+            })
+
+            UIManager:show(confirm_dialog)
+        end
+    end
+
+    dialog = ProgressbarDialog:new({
+        title = _(title),
+        progress_max = 100,
+        refresh_time_seconds = 3,
+        dismissable = dismiss_callback ~= nil,
+        dismiss_callback = dismiss_callback,
+    })
+
+    UIManager:show(dialog)
+
+    local function update_callback(progress, total_progress)
+        dialog.progress_max = total_progress
+        dialog:reportProgress(progress)
+    end
+
+    local function close_callback()
+        UIManager:close(dialog)
+    end
+
+    return update_callback, close_callback
+end
+
 ---@param progress ReadingSessionProgress
 function DialogManager:showApplyProgressConfirmation(progress)
     -- TODO:

--- a/grimmory.koplugin/main.lua
+++ b/grimmory.koplugin/main.lua
@@ -323,12 +323,19 @@ function Grimmory:onGrimmorySync(verbose)
 
         logger:info("Synchronizing to Grimmory")
 
+        local should_terminate = false
+
+        local update_callback, close_callback
         if verbose then
-            self.dialog_manager:toast(
-                _("Starting Grimmory sync...")
+            update_callback, close_callback = self.dialog_manager:showProgressDialog(
+                _("Synchronizing to Grimmory"),
+                function()
+                    should_terminate = true
+                end
             )
         end
 
+        local indeterminate_progress = 0
         local session_count = 0
         local session_error_count = 0
         local book_count = 0
@@ -341,10 +348,18 @@ function Grimmory:onGrimmorySync(verbose)
             function(progress_callback)
                 self.synchronizer:synchronizeAll(progress_callback)
             end,
-            function(progress)
+            function(progress, terminate)
+                if should_terminate then
+                    terminate()
+                end
+
                 if type(progress) ~= "table" then
                     return
                 end
+
+                indeterminate_progress = (indeterminate_progress + 1) % 20
+                update_callback(indeterminate_progress, 20)
+
 
                 if progress.since then
                     -- Update since
@@ -362,6 +377,10 @@ function Grimmory:onGrimmorySync(verbose)
                 end
             end
         )
+
+        if close_callback then
+            close_callback()
+        end
 
         if not ok then
             logger:err("Failed sync", result)


### PR DESCRIPTION
this adds a progress bar that can be dismissed to to show progress of the sync and cancel the sync

However, it doesn't track full progress, just that things are happening - so it's an indeterminate amount of progress happening.  Every 100 events that happen, it will reset the progress.

This shows that things are happening but avoids having to decide on what actually means progress / totals for that / etc.

eventually we should support clearer progress, though.