### PR TITLE
fix: handle multiple return values for `getAccessToken`

### DIFF
--- a/grimmory.koplugin/grimmory/grimmory_api.lua
+++ b/grimmory.koplugin/grimmory/grimmory_api.lua
@@ -140,6 +140,10 @@ end
 ---@param base_uri string
 ---@param username string
 ---@param password string
+---@return boolean ok
+---@return string | nil access_token
+---@return string | nil refresh_token
+---@return number expiry
 function GrimmoryAPI:getToken(base_uri, username, password)
     local uri = base_uri .. "/api/v1/auth/login"
 
@@ -154,7 +158,8 @@ function GrimmoryAPI:getToken(base_uri, username, password)
         return false, nil, nil, 0
     end
 
-    return ok, body["accessToken"], body["refreshToken"], tonumber(body["expires"])
+    local expiry = tonumber(body["expires"]) or 0
+    return ok, body["accessToken"], body["refreshToken"], expiry
 end
 
 
@@ -291,11 +296,15 @@ end
 function GrimmoryAPI:testConnection(base_uri, username, password)
     base_uri = base_uri:gsub("/+$", "")
 
-    local access_token = self:getToken(
+    local access_token_ok, access_token = self:getToken(
         base_uri,
         username,
         password
     )
+
+    if not access_token_ok then
+        return false, access_token
+    end
 
     local headers = {}
 

--- a/grimmory.koplugin/grimmory/grimmory_api.lua
+++ b/grimmory.koplugin/grimmory/grimmory_api.lua
@@ -1,3 +1,4 @@
+local _ = require("gettext")
 local http = require("socket.http")
 local https = require("ssl.https")
 local json = require("json")
@@ -303,7 +304,7 @@ function GrimmoryAPI:testConnection(base_uri, username, password)
     )
 
     if not access_token_ok then
-        return false, access_token
+        return false, _("Failed to retrieve access token")
     end
 
     local headers = {}


### PR DESCRIPTION
the `getAccessToken` return type wasn't properly defined so luacheck didn't catch it being passed improperly.

fixes #7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced token field normalization with improved handling of missing or invalid expiration data, applying reliable default values.
  * Improved connection testing stability.

* **Documentation**
  * Updated API return value documentation to reflect current behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory.koplugin/pull/9?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->