### PR TITLE
fix: properly pass seconds to `os.time`

### DIFF
--- a/grimmory.koplugin/grimmory/grimmory_api.lua
+++ b/grimmory.koplugin/grimmory/grimmory_api.lua
@@ -35,7 +35,7 @@ local function fromISO8601(value)
         day = day,
         hour = hour,
         min = min,
-        ec = sec
+        sec = sec
     })
 end
 


### PR DESCRIPTION
we previously passed `ec` as part of the table but instead should be passing `sec`