### PR TITLE
fix: don't show confirm dialog when the close callback is used

### DIFF
--- a/grimmory.koplugin/grimmory/ui/dialog_manager.lua
+++ b/grimmory.koplugin/grimmory/ui/dialog_manager.lua
@@ -362,9 +362,17 @@ end
 
 function DialogManager:showProgressDialog(title, dismiss_callback)
     local dialog
+    local is_closing = false
 
     if dismiss_callback ~= nil then
         dismiss_callback = function()
+            if is_closing then
+                -- The dismiss callback is fired even when
+                -- an outside force is trying to close the
+                -- dialog.
+                return
+            end
+
             local confirm_dialog = ConfirmBox:new({
                 text = _("Cancel Synchronization?"),
                 ok_callback = function()
@@ -393,6 +401,7 @@ function DialogManager:showProgressDialog(title, dismiss_callback)
     end
 
     local function close_callback()
+        is_closing = true
         UIManager:close(dialog)
     end
 


### PR DESCRIPTION
the dismiss callback is fired even when we are closing the progress dialog because it's done - this adds a code branch to avoid the dismiss confirmation dialog / callback from firing in that case

fixes #8 