### PR TITLE
chore: update sync interrupt message

### DIFF
--- a/grimmory.koplugin/grimmory/ui/dialog_manager.lua
+++ b/grimmory.koplugin/grimmory/ui/dialog_manager.lua
@@ -360,11 +360,15 @@ function DialogManager:showPluginUpdater()
     end)
 end
 
-function DialogManager:showProgressDialog(title, dismiss_callback)
+function DialogManager:showProgressDialog(title, dismiss_callback, dismiss_text)
     local dialog
     local is_closing = false
 
     if dismiss_callback ~= nil then
+        if dismiss_text == nil then
+            dismiss_text = _("Terminate this task?")
+        end
+
         dismiss_callback = function()
             if is_closing then
                 -- The dismiss callback is fired even when
@@ -374,7 +378,7 @@ function DialogManager:showProgressDialog(title, dismiss_callback)
             end
 
             local confirm_dialog = ConfirmBox:new({
-                text = _("Cancel Synchronization?"),
+                text = dismiss_text,
                 ok_callback = function()
                     pcall(dismiss_callback)
                     UIManager:close(dialog)

--- a/grimmory.koplugin/main.lua
+++ b/grimmory.koplugin/main.lua
@@ -331,7 +331,8 @@ function Grimmory:onGrimmorySync(verbose)
                 _("Synchronizing to Grimmory"),
                 function()
                     should_terminate = true
-                end
+                end,
+                _("Are you sure you want to interrupt synchronization?")
             )
         end
 


### PR DESCRIPTION
this updates the sync interrupt message to be clearer - it was a bit confusing before

it used to just be `Cancel Synchronization?`

<img width="889" height="267" alt="Screenshot From 2026-05-27 13-49-24" src="https://github.com/user-attachments/assets/908ff4ed-26ce-42b3-aa0b-da84d4ccec21" />

fixes #15 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Progress dialogs now support customizable confirmation messages when users dismiss ongoing operations, while maintaining localized default messaging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory.koplugin/pull/16?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->