### PR TITLE
fix: close dismiss dialog when progress dialog is closed

### DIFF
--- a/grimmory.koplugin/grimmory/ui/dialog_manager.lua
+++ b/grimmory.koplugin/grimmory/ui/dialog_manager.lua
@@ -362,6 +362,7 @@ end
 
 function DialogManager:showProgressDialog(title, dismiss_callback)
     local dialog
+    local confirm_dialog
     local is_closing = false
 
     if dismiss_callback ~= nil then
@@ -373,7 +374,11 @@ function DialogManager:showProgressDialog(title, dismiss_callback)
                 return
             end
 
-            local confirm_dialog = ConfirmBox:new({
+            if confirm_dialog then
+                UIManager:close(confirm_dialog)
+            end
+
+            confirm_dialog = ConfirmBox:new({
                 text = _("Cancel Synchronization?"),
                 ok_callback = function()
                     pcall(dismiss_callback)
@@ -402,6 +407,11 @@ function DialogManager:showProgressDialog(title, dismiss_callback)
 
     local function close_callback()
         is_closing = true
+
+        if confirm_dialog then
+            UIManager:close(confirm_dialog)
+        end
+
         UIManager:close(dialog)
     end
 


### PR DESCRIPTION
when the progress dialog is closed, the dismiss callback no longer matters.  this change updates the progress dialog closing to also close the dismissal dialog

fixes #17 