### PR TITLE
fix: properly interrupt foreground sync

### DIFF
--- a/grimmory.koplugin/grimmory/ui/dialog_manager.lua
+++ b/grimmory.koplugin/grimmory/ui/dialog_manager.lua
@@ -365,33 +365,31 @@ function DialogManager:showProgressDialog(title, dismiss_callback, dismiss_text)
     local confirm_dialog
     local is_closing = false
 
-    if dismiss_callback ~= nil then
-        if dismiss_text == nil then
-            dismiss_text = _("Terminate this task?")
+    if dismiss_text == nil then
+        dismiss_text = _("Terminate this task?")
+    end
+
+    local confirm_dismiss = function()
+        if is_closing then
+            -- The dismiss callback is fired even when
+            -- an outside force is trying to close the
+            -- dialog.
+            return
         end
 
-        dismiss_callback = function()
-            if is_closing then
-                -- The dismiss callback is fired even when
-                -- an outside force is trying to close the
-                -- dialog.
-                return
-            end
-
-            if confirm_dialog then
-                UIManager:close(confirm_dialog)
-            end
-
-            confirm_dialog = ConfirmBox:new({
-                text = dismiss_text,
-                ok_callback = function()
-                    pcall(dismiss_callback)
-                    UIManager:close(dialog)
-                end,
-            })
-
-            UIManager:show(confirm_dialog)
+        if confirm_dialog then
+            UIManager:close(confirm_dialog)
         end
+
+        confirm_dialog = ConfirmBox:new({
+            text = dismiss_text,
+            ok_callback = function()
+                pcall(dismiss_callback)
+                UIManager:close(dialog)
+            end,
+        })
+
+        UIManager:show(confirm_dialog)
     end
 
     dialog = ProgressbarDialog:new({
@@ -399,7 +397,7 @@ function DialogManager:showProgressDialog(title, dismiss_callback, dismiss_text)
         progress_max = 100,
         refresh_time_seconds = 3,
         dismissable = dismiss_callback ~= nil,
-        dismiss_callback = dismiss_callback,
+        dismiss_callback = confirm_dismiss,
     })
 
     UIManager:show(dialog)

--- a/grimmory.koplugin/main.lua
+++ b/grimmory.koplugin/main.lua
@@ -384,12 +384,22 @@ function Grimmory:onGrimmorySync(verbose)
         end
 
         if not ok then
-            logger:err("Failed sync", result)
+            if should_terminate then
+                logger:info("Sync was interrupted by user")
 
-            if verbose then
-                self.dialog_manager:toast(
-                    T(_("Failed to Synchronize to Grimmory"))
-                )
+                if verbose then
+                    self.dialog_manager:toast(
+                        _("Grimmory synchronization has been interrupted")
+                    )
+                end
+            else
+                logger:err("Failed sync", result)
+
+                if verbose then
+                    self.dialog_manager:toast(
+                        _("Failed to Synchronize to Grimmory")
+                    )
+                end
             end
 
             return


### PR DESCRIPTION
The way the dismiss confirmation dialog was being created prevented us from actually interrupting the Grimmory sync.

This fixes that & also prevents a "failed" message from appearing.

fixes #18 

<img width="889" height="267" alt="Screenshot From 2026-05-27 14-08-02" src="https://github.com/user-attachments/assets/9e777991-1db5-463c-aa12-69a4967bc598" />
