### PR TITLE
chore: add issue template for bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,141 @@
+name: Bug report
+description: Create a bug report to help us improve the plugin
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+
+  - type: checkboxes
+    id: preflight-checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: Searched existing issues for similar reports.
+          required: true
+
+  - type: dropdown
+    id: device-type
+    attributes:
+      label: Device
+      description: What type of device are you experiencing the problem on?
+      options:
+        - Kindle
+        - Kobo
+        - Cervantes
+        - Pocketbook
+        - ReMarkable
+        - Android
+        - Linux (AppImage)
+        - Linux (Deb / generic)
+        - Linux (Flatpak)
+        - MacOS (Intel)
+        - MacOS (Apple Silicon, M1, M2, …)
+        - Other (please specify in additional information)
+    validations:
+      required: true
+
+  - type: input
+    id: plugin-version
+    attributes:
+      label: Plugin version
+      description: What version of the plugin are you running?
+      placeholder: e.g., 0.0.10, 0.1.3
+    validations:
+      required: true
+
+  - type: input
+    id: koreader-version
+    attributes:
+      label: KOReader version
+      description: What version of KOReader are you running?
+      placeholder: e.g., 2026.03, 2025.10-164-gf12ff96ad_2026-03-03
+    validations:
+      required: true
+
+  - type: input
+    id: device-model
+    attributes:
+      label: Model and firmware version
+      description: Please specify your device model and firmware version if applicable
+      placeholder: e.g., Kindle Paperwhite 4 (5.16.3), Kobo Clara HD (4.38.23171)
+    validations:
+      required: false
+
+  - type: textarea
+    id: issue-description
+    attributes:
+      label: Issue description
+      description: Please describe the issue in detail
+      placeholder: What happened? What did you expect to happen?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: regression
+    attributes:
+      label: Regression
+      description: Did this issue start happening after a recent update?
+      options:
+        - "Yes" # Yes and no are booleans that must be quoted.
+        - "No"
+        - "Not sure"
+    validations:
+      required: true
+
+  - type: input
+    id: last-working-version
+    attributes:
+      label: Last working version
+      description: If this issue is a regression, please specify the last version of the Plugin / KOReader where the issue did not occur.
+      placeholder: e.g., plugin version 0.1.4 on Koreader 2026.03
+    validations:
+      required: false
+
+  - type: textarea
+    id: reproduction-steps
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce this issue?
+      value: |
+        1. Go to '...'
+        2. Click on '...'
+        3. Scroll down to '...'
+        4. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: crash-log
+    attributes:
+      label: Log
+      description: |
+        Logs are written to `crash.log`. It can normally be found in the KOReader directory:
+        * Cervantes: `/mnt/private/koreader`
+        * Kindle: `koreader/`
+        * Kobo: `.adds/koreader/`
+        * Pocketbook: `applications/koreader/`
+        * Android: Go to [Menu] → Help → Bug Report to save logs to a file
+        * AppImage: Run `koreader-20xx.AppImage 2>&1 | tee crash.log` from the terminal
+        * Deb / Linux: Run `koreader-20xx 2>&1 | tee crash.log` from the terminal
+        * Flatpak: Run `flatpak run rocks.koreader.KOReader 2>&1 | tee crash.log` from the terminal
+      placeholder: Paste the log here or drag and drop the file (zipped if necessary)
+      render: shell
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        **Note:** For non-crash issues, please enable verbose logging:
+        Go to Top menu → Hamburger menu → Help → Report a bug and tap 'Enable verbose logging'.
+        Restart as requested, then repeat the steps for your issue.
+
+  - type: textarea
+    id: additional-information
+    attributes:
+      label: Additional information
+      description: Any additional information, configuration, or data that might be necessary to reproduce the issue
+      placeholder: Add any other context about the problem here
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -110,6 +110,8 @@ body:
     attributes:
       label: Log
       description: |
+        Logs may contain sensitive information that require redaction - such as usernames, device identifiers,
+        or other personally identifying information.
         Logs are written to `crash.log`. It can normally be found in the KOReader directory:
         * Cervantes: `/mnt/private/koreader`
         * Kindle: `koreader/`


### PR DESCRIPTION
adds a cool issue template that was fairly shamelessly taken from KOReader

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new structured GitHub issue template for bug reports. The template guides contributors through a comprehensive multi-step form with required fields for device information, software versions, detailed issue descriptions, and step-by-step reproduction instructions, along with optional sections for crash logs and additional context to improve overall bug report quality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory.koplugin/pull/23?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->