### PR TITLE
fix: use proper string concatenation operator

### DIFF
--- a/grimmory.koplugin/main.lua
+++ b/grimmory.koplugin/main.lua
@@ -410,10 +410,10 @@ function Grimmory:onGrimmorySync(verbose)
             if session_error_count > 0 or book_error_count > 0 then
                 message = T(
                     _(
-                        "Completed Grimmory sync\n" +
-                        "%1 session(s) recorded\n" +
-                        "%2 session(s) failed\n" +
-                        "%3 book(s) downloaded\n" +
+                        "Completed Grimmory sync\n" ..
+                        "%1 session(s) recorded\n" ..
+                        "%2 session(s) failed\n" ..
+                        "%3 book(s) downloaded\n" ..
                         "%4 book(s) failed"
                     ),
                     session_count,


### PR DESCRIPTION
the "unhappy path" message was split across multiple lines but used arithmetic rather than concat operations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code consistency in synchronization status message handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory.koplugin/pull/24?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->