### PR TITLE
fix: use correct file extension when generating name off book ID

### DIFF
--- a/grimmory.koplugin/grimmory/synchronize.lua
+++ b/grimmory.koplugin/grimmory/synchronize.lua
@@ -322,6 +322,7 @@ function GrimmorySynchronize:downloadBook(book_id, download_path)
     return true, nil
 end
 
+---@param book Book
 function GrimmorySynchronize:getBookDownloadPath(book)
     local download_directory = self.settings:getSyncDownloadDirectory()
 
@@ -345,13 +346,13 @@ function GrimmorySynchronize:getBookDownloadPath(book)
     -- At this point we need a fallback name.  `download-${BOOK_ID}.${EXT}` is not
     -- great but I don't know a better safe way off hand.
 
-    local file_extension = util.getFileNameSuffix(book.filename)
+    local file_extension = util.getFileNameSuffix(book.primary_file.filename)
 
     if file_extension == "" or file_extension == nil then
         file_extension = "bin"
     end
 
-     download_path = download_directory .. "/downloaded-" .. tonumber(book.id) .. "." .. file_extension
+    download_path = download_directory .. "/downloaded-" .. tonumber(book.id) .. "." .. file_extension
 
     -- If this path doesn't exist yet, we're good?
     if not util.fileExists(download_path) then


### PR DESCRIPTION
there was a mismatch in the typing for `getDownloadPath` so the book `filename` property was getting accessed but that never existed.  instead, switch to `primary.fileName` so that we get a correct file extension for generated book names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined file extension detection for downloaded books, ensuring proper format identification and improved consistency in how book files are stored and managed within the application.

* **Documentation**
  * Added documentation comments to enhance code clarity for book download and synchronization functions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory.koplugin/pull/26?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->