### PR TITLE
fix: start syncing from when last session ended

### DIFF
--- a/grimmory.koplugin/grimmory/synchronize.lua
+++ b/grimmory.koplugin/grimmory/synchronize.lua
@@ -89,7 +89,7 @@ function GrimmorySynchronize:synchronizeSessions(callback)
             callback({
                 state = "session-skip",
                 bookPath = session.book_path,
-                since = session.start_time,
+                since = session.end_time,
             })
         else
             logger:dbg(
@@ -126,14 +126,14 @@ function GrimmorySynchronize:synchronizeSessions(callback)
                 callback({
                     state = "session-recorded",
                     bookPath = session.book_path,
-                    since = session.start_time,
+                    since = session.end_time,
                 })
             else
                 logger:err("Session failed recording with error for book: ", session.book_path, " - ", body)
                 callback({
                     state = "session-error",
                     bookPath = session.book_path,
-                    since = session.start_time,
+                    since = session.end_time,
                 })
             end
         end


### PR DESCRIPTION
every time a sync occurs, the last session would always be sent - this was because we would always search from the start time of the session rather than the end time - so the session would continue to be added over and over again.

this changes the sync so that the sync progress is continued from the END of a session rather than the start

fixes #22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected session synchronization timestamps to report completion times instead of start times for session state updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory.koplugin/pull/30?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->