### PR TITLE
docs: use correct github repo for latest plugin zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,4 @@ to the latest release.
 
 Distributed under the terms of the [AGPL-3.0 License](./LICENSE).
 
-[latest-plugin]: https://github.com/imnotjames/grimmory.koplugin/releases/latest/download/grimmory.koplugin.zip
+[latest-plugin]: https://github.com/grimmory-tools/grimmory.koplugin/releases/latest/download/grimmory.koplugin.zip


### PR DESCRIPTION
the link was to the old repo and not the current one