### PR TITLE
fix: make threshold checks independent

### DIFF
--- a/grimmory.koplugin/grimmory/synchronize.lua
+++ b/grimmory.koplugin/grimmory/synchronize.lua
@@ -84,8 +84,15 @@ function GrimmorySynchronize:synchronizeSessions(callback)
         local total_seconds = session.end_time - session.start_time
         local total_pages = session.end_page - session.start_page + 1
 
-        if total_seconds < threshold_seconds and total_pages < threshold_pages then
-            logger:info("Session skipped for book", session.book_path)
+        if total_seconds < threshold_seconds then
+            logger:info("Skipped session below time threshold for book", session.book_path)
+            callback({
+                state = "session-skip",
+                bookPath = session.book_path,
+                since = session.end_time,
+            })
+        elseif total_pages < threshold_pages then
+            logger:info("Skipped session below page threshold for book", session.book_path)
             callback({
                 state = "session-skip",
                 bookPath = session.book_path,


### PR DESCRIPTION
The previous threshold logic would only skip a session if it was below BOTH the time and page count.  This is non-ideal since the page count threshold by default is "off".

This PR updates the thresholds to operate independently - including the log messages

fixes #31