### PR TITLE
fix: reading progress percentage need to be multiplied by 100

### DIFF
--- a/grimmory.koplugin/grimmory/reading/repository.lua
+++ b/grimmory.koplugin/grimmory/reading/repository.lua
@@ -304,7 +304,7 @@ function ReadingSessionRepository:getReadingProgress(look_back)
                 local end_progress = 0
 
                 if page_count > 0 then
-                    end_progress = end_page / page_count
+                    end_progress = (end_page / page_count) * 100
                 end
 
                 ---@type ReadingSessionProgress
@@ -384,7 +384,7 @@ function ReadingSessionRepository:getReadingProgressForBook(book_md5, look_back)
             local end_progress = 0
 
             if page_count > 0 then
-                end_progress = end_page / page_count
+                end_progress = (end_page / page_count) * 100
             end
 
             return {
@@ -499,7 +499,11 @@ function ReadingSessionRepository:getSessions(since)
         -- to end of page?  But for now the simplest is to count
         -- progress as a point-in-time.
 
-        local read_progress = event.page / event.page_count
+        -- Percentage read via page count.
+        local read_progress = 0
+        if event.page_count > 0 then
+            read_progress = (event.page / event.page_count) * 100
+        end
 
         -- If existing session, we should update.
         -- We can make the assumption that these are in


### PR DESCRIPTION
the reading progress percentages were not being sent out of 100 thus were incorrect

<img width="1190" height="115" alt="image" src="https://github.com/user-attachments/assets/ee732be6-757e-4d41-9f3e-b0ec28d22826" />

fixes #41

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reading session progress metrics are now calculated and displayed as percentages instead of decimal values, providing clearer progress indication.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory.koplugin/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->