### PR TITLE
chore: remove spurious log messages

### DIFF
--- a/grimmory.koplugin/grimmory/reading/progress_manager.lua
+++ b/grimmory.koplugin/grimmory/reading/progress_manager.lua
@@ -50,7 +50,7 @@ function ReadingProgressManager:getNewerProgressForBook(book_path)
     local remote_name, remote_id, remote_progress = self:getRemoteProgressForBook(book_path)
 
     if compareProgress(local_progress, remote_progress) <= 0 then
-        logger:info("No new progress for book:", book_path)
+        logger:dbg("No new progress for book:", book_path)
         return nil, nil, nil
     end
 

--- a/grimmory.koplugin/grimmory/ui/dialog_manager.lua
+++ b/grimmory.koplugin/grimmory/ui/dialog_manager.lua
@@ -139,7 +139,7 @@ function DialogManager:showTargetShelvesSettings()
             {
                 text = _("All Shelves"),
                 callback = function()
-                    logger:info("Set target shelves to All Shelves")
+                    logger:dbg("Set target shelves to All Shelves")
                     self.settings:setSyncTargetShelves({})
 
                     UIManager:broadcastEvent(Event:new("GrimmorySettingsChanged"))
@@ -169,7 +169,7 @@ function DialogManager:showTargetShelvesSettings()
                 {
                     text = uniqueShelfName,
                     callback = function()
-                        logger:info("Set target shelves to shelf ID", shelfId)
+                        logger:dbg("Set target shelves to shelf ID", shelfId)
                         self.settings:setSyncTargetShelves({ { id = shelfId, name = uniqueShelfName } })
 
                         UIManager:broadcastEvent(Event:new("GrimmorySettingsChanged"))

--- a/grimmory.koplugin/main.lua
+++ b/grimmory.koplugin/main.lua
@@ -311,12 +311,10 @@ function Grimmory:isReadyToSync()
 end
 
 function Grimmory:onGrimmorySyncForegound()
-    logger:info("FOREGROUND")
     return self:onGrimmorySync(true)
 end
 
 function Grimmory:onGrimmorySyncBackground()
-    logger:info("BG")
     return self:onGrimmorySync(false)
 end
 


### PR DESCRIPTION
a few log messages can be removed as they were only for testing or can be moved to `dbg` level