### PR TITLE
fix: normalize progress to 100% when reading from API

### DIFF
--- a/grimmory.koplugin/grimmory/reading/progress_manager.lua
+++ b/grimmory.koplugin/grimmory/reading/progress_manager.lua
@@ -135,7 +135,7 @@ function ReadingProgressManager:pushRemoteProgress(progress)
         device_id,
         progress.book_md5,
         progress.end_time,
-        progress.end_progress,
+        progress.end_progress / 100,
         progress.end_xpointer or progress.end_page
     )
 
@@ -192,7 +192,7 @@ function ReadingProgressManager:getRemoteProgressForBook(book_path)
         book_path = book_path,
         book_md5 = progress.document,
         end_time = progress.timestamp,
-        end_progress = progress.percentage,
+        end_progress = progress.percentage * 100,
         end_page = page,
         end_xpointer = xpointer,
     }

--- a/grimmory.koplugin/grimmory/ui/dialog_manager.lua
+++ b/grimmory.koplugin/grimmory/ui/dialog_manager.lua
@@ -436,7 +436,7 @@ function DialogManager:showApplyProgressConfirmation(progress)
     local dialog = ConfirmBox:new({
         text = T(
             _("Go to latest location %1% from Grimmory?"),
-            tostring(progress.end_progress * 100)
+            tostring(progress.end_progress)
         ),
         ok_callback = function()
             self.reading_progress_manager:applyProgress(progress)


### PR DESCRIPTION
This normalizes the progress to 100% rather than having a mismatch between Koreader & Grimmory.

Testing included re-pushing old progress and inspecting it in Grimmory, then opening a book and ensuring that the progress was pushed to the correct location.

fixes #49

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected reading progress synchronization between local and remote storage
  * Fixed progress value display in confirmation dialogs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory.koplugin/pull/52?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->