### PR TITLE
fix: handle invalid types during update gracefully

### DIFF
--- a/grimmory.koplugin/grimmory/ota/self_updater.lua
+++ b/grimmory.koplugin/grimmory/ota/self_updater.lua
@@ -66,6 +66,11 @@ local function findPluginInArchive(reader)
 end
 
 ---@param version string
+---@return number major
+---@return number minor
+---@return number patch
+---@return string | nil prerelease
+---@return string | nil build
 local function parseVersion(version)
     local major, minor, patch, labels = tostring(version):match("v?(%d+)%.(%d+)%.(%d+)(.*)")
 
@@ -85,7 +90,7 @@ local function parseVersion(version)
         end
     end
 
-    return tonumber(major), tonumber(minor), tonumber(patch), prerelease, build
+    return tonumber(major) or 0, tonumber(minor) or 0, tonumber(patch) or 0, prerelease, build
 end
 
 ---@param version_a string


### PR DESCRIPTION
if the version returned is not matching the expected value we can get `nil` returned back in major / minor / patch.  this defines the return types & ensures a number is always returned

fixes #21 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version parsing reliability during self-updates to handle edge cases more gracefully.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory.koplugin/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->