### PR TITLE
fix: support missing plugin metadata

### DIFF
--- a/grimmory.koplugin/grimmory/grimmory_api.lua
+++ b/grimmory.koplugin/grimmory/grimmory_api.lua
@@ -4,7 +4,7 @@ local https = require("ssl.https")
 local json = require("json")
 local ltn12 = require("ltn12")
 
-local PluginMetadata = require("_meta")
+local PluginMetadata = require("grimmory/plugin_metadata")
 local GrimmoryLogger = require("grimmory/logger")
 
 local logger = GrimmoryLogger:new()
@@ -93,7 +93,7 @@ local function parseBook(book)
 end
 
 local function getUserAgent()
-    return "grimmory.koplugin/" .. PluginMetadata.version .. " (" .. PluginMetadata.repository .. ")"
+    return "grimmory.koplugin/" .. PluginMetadata.getVersion() .. " (" .. PluginMetadata.getRepository() .. ")"
 end
 
 ---@class GrimmoryAPI

--- a/grimmory.koplugin/grimmory/ota/github_api.lua
+++ b/grimmory.koplugin/grimmory/ota/github_api.lua
@@ -3,7 +3,7 @@ local https = require("ssl.https")
 local json = require("json")
 local ltn12 = require("ltn12")
 
-local PluginMetadata = require("_meta")
+local PluginMetadata = require("grimmory/plugin_metadata")
 local GrimmoryLogger = require("grimmory/logger")
 
 local logger = GrimmoryLogger:new()
@@ -23,7 +23,7 @@ function GithubAPI:new(o)
 end
 
 function GithubAPI:getUserAgent()
-    return "grimmory.koplugin/" .. PluginMetadata.version .. " (" .. PluginMetadata.repository .. ")"
+    return "grimmory.koplugin/" .. PluginMetadata.getVersion() .. " (" .. PluginMetadata.getRepository() .. ")"
 end
 
 function GithubAPI:request(method, uri, data, sink)

--- a/grimmory.koplugin/grimmory/ota/self_updater.lua
+++ b/grimmory.koplugin/grimmory/ota/self_updater.lua
@@ -7,7 +7,7 @@ local NetworkManager = require("ui/network/manager")
 local util = require("util")
 local sha2 = require("ffi/sha2")
 
-local PluginMetadata = require("_meta")
+local PluginMetadata = require("grimmory/plugin_metadata")
 local GrimmoryLogger = require("grimmory/logger")
 
 local logger = GrimmoryLogger:new()
@@ -138,7 +138,7 @@ function GrimmorySelfUpdater:isPendingRestart()
 end
 
 function GrimmorySelfUpdater:isUpdateAvailable()
-    local current_version = "v" .. PluginMetadata.version
+    local current_version = "v" .. PluginMetadata.getVersion()
     local latest_version = self.latest_known_version or current_version
 
     return isVersionLater(current_version, latest_version)
@@ -146,13 +146,18 @@ end
 
 function GrimmorySelfUpdater:getLatestReleaseVersion()
     -- Get the latest release version from github
-    local current_version = "v" .. PluginMetadata.version
+    local current_version = "v" .. PluginMetadata.getVersion()
     return self.latest_known_version or current_version
 end
 
 function GrimmorySelfUpdater:fetchLatestVersion()
+    if not PluginMetadata.hasRepository() then
+        logger:warn("Unknown repository - cannot fetch latest version")
+        return
+    end
+
     local ok, version = self.github_api:getLatestReleaseVersion(
-        PluginMetadata.repository
+        PluginMetadata.getRepository()
     )
 
     if not ok or not version then
@@ -168,6 +173,11 @@ function GrimmorySelfUpdater:downloadLatestRelease(progress_callback)
         return false, g("No latest release")
     end
 
+    if not PluginMetadata.hasRepository() then
+        logger:warn("Unknown repository - cannot fetch latest version")
+        return false, g("No repository defined")
+    end
+
     local download_path = self.release_cache_path ..
         "/plugin-" .. self.latest_known_version ..
         "-" .. os.time() .. ".zip"
@@ -180,7 +190,7 @@ function GrimmorySelfUpdater:downloadLatestRelease(progress_callback)
     end
 
     local ok, result, asset = self.github_api:downloadReleaseArchive(
-        PluginMetadata.repository,
+        PluginMetadata.getRepository(),
         self.latest_known_version,
         self.release_asset_name,
         download_path,

--- a/grimmory.koplugin/grimmory/plugin_metadata.lua
+++ b/grimmory.koplugin/grimmory/plugin_metadata.lua
@@ -1,0 +1,29 @@
+local _meta = require("_meta")
+
+local PluginMetadata = {}
+
+
+---@return boolean has_repository
+function PluginMetadata.hasRepository()
+    return _meta.repository ~= nil
+end
+
+---@return string version
+function PluginMetadata.getVersion()
+    if _meta.version == nil then
+        return "0.0.0-snapshot"
+    end
+
+    return tostring(_meta.version)
+end
+
+---@return string repository
+function PluginMetadata.getRepository()
+    if _meta.version == nil then
+        return "unknown repository"
+    end
+
+    return tostring(_meta.repository)
+end
+
+return PluginMetadata

--- a/grimmory.koplugin/grimmory/ui/menu.lua
+++ b/grimmory.koplugin/grimmory/ui/menu.lua
@@ -4,7 +4,7 @@ local T = require("ffi/util").template
 local Event = require("ui/event")
 local UIManager = require("ui/uimanager")
 
-local PluginMetadata = require("_meta")
+local PluginMetadata = require("grimmory/plugin_metadata")
 local GrimmoryLogger = require("grimmory/logger")
 
 local logger = GrimmoryLogger:new()
@@ -24,8 +24,8 @@ end
 
 function GrimmoryMenu:getAboutMenu()
     -- These won't change after the plugin starts up
-    local repository = PluginMetadata.repository
-    local version = PluginMetadata.version
+    local repository = PluginMetadata.getRepository()
+    local version = PluginMetadata.getVersion()
 
     return {
         {


### PR DESCRIPTION
in some cases, the plugin metadata has been coming through as `nil` - this handles tat case to prevent unexpected failures by always having a fallback and preventing automatic updates when the repository is missing

fixes #21 