### PR TITLE
fix: only call the update callback when not nil

### DIFF
--- a/grimmory.koplugin/main.lua
+++ b/grimmory.koplugin/main.lua
@@ -368,8 +368,9 @@ function Grimmory:onGrimmorySync(verbose)
                 end
 
                 indeterminate_progress = (indeterminate_progress + 1) % 20
-                update_callback(indeterminate_progress, 20)
-
+                if update_callback ~= nil then
+                    pcall(update_callback, indeterminate_progress, 20)
+                end
 
                 if progress.since then
                     -- Update since


### PR DESCRIPTION
the sync update callback fails when the sync is done in the background.  this means that the session update pointer was never being pushed forward and the sessions would be pushed over and over

fixes #56 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization error handling to prevent crashes when optional callbacks are unavailable and to better isolate callback exceptions during the sync process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory.koplugin/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->