### PR TITLE
feat: allow interrupting background sync from menu

### DIFF
--- a/grimmory.koplugin/grimmory/ui/menu.lua
+++ b/grimmory.koplugin/grimmory/ui/menu.lua
@@ -2,6 +2,7 @@ local _ = require("gettext")
 local T = require("ffi/util").template
 
 local Event = require("ui/event")
+local ConfirmBox = require("ui/widget/confirmbox")
 local UIManager = require("ui/uimanager")
 
 local PluginMetadata = require("grimmory/plugin_metadata")
@@ -13,6 +14,7 @@ local logger = GrimmoryLogger:new()
 ---@field settings GrimmorySettings
 ---@field dialog_manager DialogManager
 ---@field updater GrimmorySelfUpdater
+---@field interrupt_sync function
 local GrimmoryMenu = {}
 
 function GrimmoryMenu:new(o)
@@ -20,6 +22,14 @@ function GrimmoryMenu:new(o)
     setmetatable(o, self)
     self.__index = self
     return o
+end
+
+function GrimmoryMenu:onGrimmorySyncStart(interrupt_sync_callback)
+    self.interrupt_sync = interrupt_sync_callback
+end
+
+function GrimmoryMenu:onGrimmorySyncComplete()
+    self.interrupt_sync = nil
 end
 
 function GrimmoryMenu:getAboutMenu()
@@ -145,22 +155,7 @@ function GrimmoryMenu:getSyncOptionsMenu()
 end
 
 function GrimmoryMenu:getTopMenu()
-    return  {
-        {
-            text = _("Force Sync Now"),
-            enabled_func = function()
-                if self.settings:getBaseUri() == "" then
-                    logger:info("BaseURI is not configured, cannot sync")
-                    return false
-                end
-
-                return true
-            end,
-            callback = function()
-                UIManager:broadcastEvent(Event:new("GrimmorySync", true))
-            end,
-            separator = true,
-        },
+    local menu = {
         {
             text = _("Connection Settings"),
             callback = function()
@@ -251,13 +246,57 @@ function GrimmoryMenu:getTopMenu()
             sub_item_table = self:getAboutMenu(),
         },
     }
+
+    if self.interrupt_sync == nil then
+        table.insert(
+            menu, 1,
+            {
+                text = _("Force Sync Now"),
+                enabled_func = function()
+                    if self.settings:getBaseUri() == "" then
+                        logger:info("BaseURI is not configured, cannot sync")
+                        return false
+                    end
+
+                    return true
+                end,
+                callback = function()
+                    UIManager:broadcastEvent(Event:new("GrimmorySync", true))
+                end,
+                separator = true,
+            }
+        )
+    else
+        table.insert(
+            menu, 1,
+            {
+                text = _("Interrupt Current Sync"),
+                callback = function()
+                    if self.interrupt_sync ~= nil then
+                        local dialog = ConfirmBox:new({
+                            text = _("Are you sure you want to interrupt synchronization?"),
+                            ok_callback = function()
+                                pcall(self.interrupt_sync)
+                            end,
+                        })
+                        UIManager:show(dialog)
+                    end
+                end,
+                separator = true,
+            }
+        )
+    end
+
+    return menu
 end
 
 function GrimmoryMenu:addToMainMenu(menu_items)
     menu_items.grimmory = {
         text = "Grimmory",
         sorting_hint = "tools",
-        sub_item_table = self:getTopMenu()
+        sub_item_table_func = function()
+            return self:getTopMenu()
+        end,
     }
 end
 

--- a/grimmory.koplugin/main.lua
+++ b/grimmory.koplugin/main.lua
@@ -345,6 +345,8 @@ function Grimmory:onGrimmorySync(verbose)
             )
         end
 
+        self.menu:onGrimmorySyncStart(function() should_terminate = true end)
+
         local indeterminate_progress = 0
         local session_count = 0
         local session_error_count = 0
@@ -456,6 +458,8 @@ function Grimmory:onGrimmorySync(verbose)
 
             self.dialog_manager:toast(message)
         end
+
+        self.menu:onGrimmorySyncComplete()
     end
 
     self.executor:wrap(function()


### PR DESCRIPTION
when a background sync is happening, we should allow interrupting the sync from the grimmory menu instead of starting a new sync

fixes #57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now interrupt active synchronization operations through the menu with a confirmation dialog, providing greater control over sync processes.
  * Menu dynamically displays appropriate sync controls based on current synchronization state.

* **Improvements**
  * Enhanced synchronization workflow with improved menu integration and lifecycle handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory.koplugin/pull/59?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->