### PR TITLE
fix: handle missing document in reading recorder

### DIFF
--- a/grimmory.koplugin/grimmory/reading/recorder.lua
+++ b/grimmory.koplugin/grimmory/reading/recorder.lua
@@ -42,6 +42,10 @@ function ReadingRecorder:getOpenBookTotalPages()
 end
 
 function ReadingRecorder:getOpenBookReadPercent()
+    if not self.ui or not self.ui.document then
+        return 0
+    end
+
     if self.ui.document.info.has_pages then
         return self.ui.paging:getLastPercent()
     else
@@ -51,7 +55,7 @@ end
 
 ---@return string | nil xpointer
 function ReadingRecorder:getOpenBookXPointer()
-    if self.ui.document.info.has_pages then
+    if not self.ui or not self.ui.document or self.ui.document.info.has_pages then
         return nil
     end
 
@@ -60,6 +64,10 @@ end
 
 ---@return string | nil book_path current book path
 function ReadingRecorder:getOpenBookPath()
+    if not self.ui or not self.ui.document then
+        return nil
+    end
+
     return self.ui.document.file
 end
 


### PR DESCRIPTION
if reading progress is on and you resume but aren't reading this caused a crash.  instead, we need to check for the status of a document before returning the book we're looking at