### PR TITLE
chore: clean up OTA upgrade dialog

### DIFF
--- a/grimmory.koplugin/grimmory/settings.lua
+++ b/grimmory.koplugin/grimmory/settings.lua
@@ -329,17 +329,4 @@ function GrimmorySettings:setSynchronizedUntil(timestamp)
     self:write()
 end
 
-function GrimmorySettings:getAutomaticCheckUpdates()
-    if self.data.automatic_check_updates == nil then
-        return DEFAULTS.automatic_check_updates
-    end
-
-    return self.data.automatic_check_updates
-end
-
-function GrimmorySettings:toggleAutomaticCheckUpdates()
-    self.data.automatic_check_updates = not self:getAutomaticCheckUpdates()
-    self:write()
-end
-
 return GrimmorySettings

--- a/grimmory.koplugin/grimmory/ui/dialog_manager.lua
+++ b/grimmory.koplugin/grimmory/ui/dialog_manager.lua
@@ -39,12 +39,15 @@ function DialogManager:toast(text, timeout)
         timeout = nil
     end
 
-    self.info_message = InfoMessage:new({
+    local info_message = InfoMessage:new({
         text = text,
         timeout = timeout,
     })
 
-    UIManager:show(self.info_message)
+    UIManager:show(info_message)
+    self.info_message = info_message
+
+    return function() UIManager:close(info_message) end
 end
 
 function DialogManager:showConnectionSettings()
@@ -289,19 +292,28 @@ function DialogManager:showDownloadDirectorySettings()
     UIManager:show(dialog)
 end
 
-function DialogManager:showPluginUpdateCheck()
+function DialogManager:showPluginUpdateCheck(skip_version_check)
+    if not skip_version_check then
+        -- Refresh the latest version on open.
+        local close_message = self:toast(_("Checking for Updates"), 0)
+        self.updater:fetchLatestVersion()
+        pcall(close_message)
+    end
+
     local dialog
     local latest_version = self.updater:getLatestReleaseVersion()
     local is_update_available = self.updater:isUpdateAvailable()
 
     local update_button_text = _("No update available")
+    local title = _("Grimmory.koplugin is currently up-to-date.")
 
     if is_update_available then
         update_button_text = T(_("Update to %1"), latest_version)
+        title = _("Update available for Grimmory.koplugin.")
     end
 
     dialog = ButtonDialog:new({
-        title = T(_("Update Grimmory Plugin\nLatest release is %1"), latest_version),
+        title = title,
         buttons = {
             {
                 {
@@ -319,7 +331,7 @@ function DialogManager:showPluginUpdateCheck()
                     callback = function()
                         self.updater:fetchLatestVersion()
                         UIManager:close(dialog)
-                        self:showPluginUpdateCheck()
+                        self:showPluginUpdateCheck(true)
                     end,
                 },
             },

--- a/grimmory.koplugin/grimmory/ui/menu.lua
+++ b/grimmory.koplugin/grimmory/ui/menu.lua
@@ -49,19 +49,6 @@ function GrimmoryMenu:getAboutMenu()
         },
         {
             text_func = function()
-                return _("Automatically Check for Updates")
-            end,
-            checked_func = function()
-                return self.settings:getAutomaticCheckUpdates()
-            end,
-            callback = function()
-                self.settings:toggleAutomaticCheckUpdates()
-                UIManager:broadcastEvent(Event:new("GrimmorySettingsChanged"))
-            end,
-            keep_menu_open = true,
-        },
-        {
-            text_func = function()
                 if self.updater:isPendingRestart() then
                     return _("Update Pending Restart")
                 end

--- a/grimmory.koplugin/main.lua
+++ b/grimmory.koplugin/main.lua
@@ -206,7 +206,6 @@ function Grimmory:onGrimmorySettingsChanged()
     logger:dbg("Settings Changed")
 
     self:onSchedulePeriodicPush()
-    self:onScheduleAutomaticUpdates()
 end
 
 function Grimmory:onSchedulePeriodicPush()
@@ -242,33 +241,6 @@ function Grimmory:onSchedulePeriodicPush()
 
         self.periodic_sync_cancel = nil
         self.periodic_sync_update = nil
-    end
-end
-
-function Grimmory:onScheduleAutomaticUpdates()
-    -- If automatic updates is enabled, schedule interval.
-    if self.settings:getAutomaticCheckUpdates() then
-        if not self.release_check_cancel then
-            local cancel, _ = self.scheduler:interval(
-                7200,
-                self.updater.fetchLatestVersion,
-                self.updater
-            )
-
-            self.release_check_cancel = cancel
-        end
-
-        self.scheduler:schedule(
-            5,
-            self.updater.fetchLatestVersion,
-            self.updater
-        )
-    else
-        if self.release_check_cancel then
-            self.release_check_cancel()
-        end
-
-        self.release_check_cancel = nil
     end
 end
 


### PR DESCRIPTION
Some minor copy text changes and drop the automatically check for updates feature.
Instead, opening the dialog will kick off a check for updates so you don't open the dialog and then press the button.

<img width="1054" height="314" alt="image" src="https://github.com/user-attachments/assets/4f5746a7-7767-4994-9fe9-aee217873e72" />

fixes #62
