### PR TITLE
feat: bucket sync status by book rather than device

### DIFF
--- a/grimmory.koplugin/grimmory/migrations/3_book_sync_status.sql
+++ b/grimmory.koplugin/grimmory/migrations/3_book_sync_status.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS book_sync_status (
+    id        integer PRIMARY KEY autoincrement,
+    book_id        INTEGER NOT NULL,
+    sync_type      VARCHAR NOT NULL,
+    last_synced_at INTEGER NOT NULL DEFAULT 0,
+    UNIQUE (book_id, sync_type)
+    FOREIGN KEY(book_id) REFERENCES book(id)
+);

--- a/grimmory.koplugin/grimmory/reading/progress_manager.lua
+++ b/grimmory.koplugin/grimmory/reading/progress_manager.lua
@@ -59,9 +59,9 @@ end
 
 ---@return ReadingSessionProgress | nil progress
 function ReadingProgressManager:getLocalProgressForBook(book_path)
-    local partial_md5 = util.partialMD5(book_path)
+    local ok, book_id = self.repository:upsertBook(book_path)
 
-    if partial_md5 == nil then
+    if not ok or book_id == nil then
         return nil
     end
 
@@ -69,9 +69,13 @@ function ReadingProgressManager:getLocalProgressForBook(book_path)
         -- This is a bit of a hack to handle the fact that the page event
         -- is fired before the reader is ready.
         -- Look back 30 seconds so the "current" session isn't counted
-        return self.repository:getReadingProgressForBook(partial_md5, 30)
+        local _, progress = self.repository:getReadingProgress(book_id, os.time() - 30)
+
+        return progress
     else
-        return self.repository:getReadingProgressForBook(partial_md5)
+        local _, progress = self.repository:getReadingProgress(book_id)
+
+        return progress
     end
 end
 

--- a/grimmory.koplugin/grimmory/repository.lua
+++ b/grimmory.koplugin/grimmory/repository.lua
@@ -323,84 +323,11 @@ function GrimmoryLocalRepository:insertBookEvent(session_id, event_type, current
     end
 end
 
----@param look_back number | nil
----@return ReadingSessionProgress[] progress
-function GrimmoryLocalRepository:getReadingProgress(look_back)
-    local ok, results = self:withDatabase(
-        function(conn)
-            local stmt = conn:prepare([[
-                SELECT
-                    book.grimmory_id,
-                    book.book_path,
-                    book.partial_md5,
-
-                    book_event.created_at,
-                    book_event.current_page,
-                    book_event.page_count,
-                    book_event.xpointer
-                FROM (
-                    SELECT
-                        s.book_id,
-                        MAX(e.id) AS event_id
-                    FROM book_event e
-                    JOIN book_session s ON s.id = e.session_id
-                    WHERE e.created_at < ?
-                    GROUP BY s.book_id
-                ) AS last_event
-                JOIN book_event ON last_event.event_id = book_event.id
-                JOIN book_session ON book_event.session_id = book_session.id
-                JOIN book ON book_session.book_id = book.id;
-            ]])
-
-            local time_threshold = os.time() - (look_back or 0)
-
-            stmt:bind(time_threshold)
-
-            ---@type ReadingSessionProgress[]
-            local results = {}
-
-            for row in stmt:rows() do
-                local end_time = tonumber(row[4], 10) or 0
-                local end_page = tonumber(row[5]) or 0
-                local page_count = tonumber(row[6]) or 0
-
-                local end_progress = 0
-
-                if page_count > 0 then
-                    end_progress = (end_page / page_count) * 100
-                end
-
-                ---@type ReadingSessionProgress
-                local progress = {
-                    grimmory_id = tonumber(row[1]),
-                    book_path = row[2],
-                    book_md5 = row[3],
-                    end_time = end_time,
-                    end_page = end_page,
-                    end_progress = end_progress,
-                    end_xpointer = row[7],
-                }
-                table.insert(results, progress)
-            end
-
-            stmt:close()
-
-            return results
-        end
-    )
-
-    if not ok then
-        logger:err("Failed to get reading progress:", results)
-        return {}
-    end
-
-    return results
-end
-
----@param book_md5 string
----@param look_back number | nil
+---@param book_id number
+---@param cutoff number | nil
+---@return boolean ok
 ---@return ReadingSessionProgress | nil progress
-function GrimmoryLocalRepository:getReadingProgressForBook(book_md5, look_back)
+function GrimmoryLocalRepository:getReadingProgress(book_id, cutoff)
     local ok, result = self:withDatabase(
         function(conn)
             local stmt = conn:prepare([[
@@ -419,22 +346,24 @@ function GrimmoryLocalRepository:getReadingProgressForBook(book_md5, look_back)
                         MAX(e.id) AS event_id
                     FROM book_event e
                     JOIN book_session s ON s.id = e.session_id
-                    WHERE e.created_at < ?
+                    WHERE
+                        e.created_at < ?
                     GROUP BY s.book_id
                 ) AS last_event
                 JOIN book_event ON last_event.event_id = book_event.id
                 JOIN book_session ON book_event.session_id = book_session.id
                 JOIN book ON book_session.book_id = book.id
-                WHERE book.partial_md5 = ?
-                LIMIT 1;
+                WHERE
+                    book.id = ?
             ]])
 
-            local time_threshold = os.time() - (look_back or 0)
+            if cutoff == nil then
+                cutoff = os.time()
+            end
 
-            stmt:bind(time_threshold, book_md5)
+            stmt:bind(cutoff, book_id)
 
-            local row = stmt:rows()()
-
+            local row = stmt:step()
             stmt:close()
 
             if row == nil then
@@ -442,7 +371,6 @@ function GrimmoryLocalRepository:getReadingProgressForBook(book_md5, look_back)
             end
 
             local end_time = tonumber(row[4], 10) or 0
-
             local end_page = tonumber(row[5]) or 0
             local page_count = tonumber(row[6]) or 0
 
@@ -453,28 +381,28 @@ function GrimmoryLocalRepository:getReadingProgressForBook(book_md5, look_back)
             end
 
             return {
-                    grimmory_id = row[1],
-                    book_path = row[2],
-                    book_md5 = row[3],
-                    end_time = end_time,
-                    end_page = end_page,
-                    end_progress = end_progress,
-                    end_xpointer = row[7],
+                grimmory_id = tonumber(row[1]),
+                book_path = row[2],
+                book_md5 = row[3],
+                end_time = end_time,
+                end_page = end_page,
+                end_progress = end_progress,
+                end_xpointer = row[7],
             }
         end
     )
 
     if not ok then
-        logger:err("Failed to get reading progress:", result)
-        return nil
+        logger:err("Failed to get reading progress:", book_id, "-", result)
+        return ok, nil
     end
 
-    return result
+    return ok, result
 end
 
----@param since integer
+---@param book_id integer
 ---@return ReadingSessionEvent[]
-function GrimmoryLocalRepository:getEvents(since)
+function GrimmoryLocalRepository:getPendingSessionEvents(book_id)
     local ok, results = self:withDatabase(
         function(conn)
             local stmt = conn:prepare([[
@@ -490,13 +418,18 @@ function GrimmoryLocalRepository:getEvents(since)
                     e.page_count,
                     e.xpointer
                 FROM book AS b
+                LEFT JOIN book_sync_status AS bss
+                    ON bss.book_id = b.id AND bss.sync_type = "sessions"
                 JOIN book_session AS s ON s.book_id = b.id
                 JOIN book_event AS e ON e.session_id = s.id
-                WHERE e.created_at > ?
+                WHERE
+                    e.created_at > COALESCE(bss.last_synced_at, 0)
+                    AND
+                    b.id = ?
                 ORDER BY b.id ASC, e.created_at ASC
             ]])
 
-            stmt:bind(since)
+            stmt:bind(book_id)
 
             ---@type ReadingSessionEvent[]
             local results = {}
@@ -556,13 +489,13 @@ local function isPartOfSession(session, event)
     end
 end
 
----@param since integer
+---@param book_id integer
 ---@return ReadingSession[]
-function GrimmoryLocalRepository:getSessions(since)
+function GrimmoryLocalRepository:getPendingSessions(book_id)
     ---@type ReadingSession[]
     local sessions = {}
 
-    for _, event in ipairs(self:getEvents(since)) do
+    for _, event in ipairs(self:getPendingSessionEvents(book_id)) do
         -- Eventually we could figure out progress from start of page
         -- to end of page?  But for now the simplest is to count
         -- progress as a point-in-time.
@@ -626,6 +559,114 @@ function GrimmoryLocalRepository:getSessions(since)
     )
 
     return sessions
+end
+
+---@alias RepositorySyncType
+---| "progress"
+---| "sessions"
+
+---@param book_id number
+---@param sync_type RepositorySyncType
+---@param timestamp number
+function GrimmoryLocalRepository:updateBookSyncTimestamp(book_id, sync_type, timestamp)
+    local ok, message = self:withDatabase(
+        function(conn)
+            local stmt = conn:prepare([[
+                INSERT INTO book_sync_status
+                    (book_id, sync_type, last_synced_at)
+                VALUES (
+                    ?,
+                    ?,
+                    ?
+                )
+                ON CONFLICT (book_id, sync_type)
+                DO UPDATE SET
+                    last_synced_at = excluded.last_synced_at
+            ]])
+
+            stmt:bind(
+                book_id,
+                sync_type,
+                timestamp
+            )
+            stmt:step()
+            stmt:close()
+        end,
+        "rw"
+    )
+
+    if not ok then
+        logger:err("Failed to update book synced at:", book_id, "-", message)
+        return false
+    end
+
+    return true
+
+end
+
+---@param with_sessions boolean
+---@param with_progress boolean
+---@return number[] book_ids
+function GrimmoryLocalRepository:getBooksPendingSync(
+    with_sessions,
+    with_progress
+)
+    local ok, book_ids = self:withDatabase(
+        function(conn)
+            local stmt = conn:prepare([[
+                SELECT
+                    book.id
+                FROM book
+                JOIN book_session ON book.id = book_session.book_id
+                JOIN book_event ON book_session.id = book_event.session_id
+                LEFT JOIN book_sync_status AS sync_sessions
+                    ON book.id = sync_sessions.book_id AND sync_sessions.sync_type = "sessions"
+                LEFT JOIN book_sync_status AS sync_progress
+                    ON book.id = sync_progress.book_id AND sync_progress.sync_type = "progress"
+                WHERE
+                    grimmory_id IS NOT NULL
+                    AND
+                    (
+                        (
+                            ? = 1
+                            AND
+                            book_event.created_at > COALESCE(sync_sessions.last_synced_at, 0)
+                        )
+                        OR
+                        (
+                            ? = 1
+                            AND
+                            book_event.created_at > COALESCE(sync_progress.last_synced_at, 0)
+                        )
+                    )
+                GROUP BY book.id
+            ]])
+
+            stmt:bind(with_sessions and 1 or 0, with_progress and 1 or 0)
+
+            ---@type number[]
+            local results = {}
+
+            for row in stmt:rows() do
+                local book_id = tonumber(row[1])
+
+                if book_id then
+                    table.insert(results, book_id)
+                end
+            end
+
+            stmt:close()
+
+            return results
+        end
+    )
+
+    if not ok or not book_ids then
+        logger:err("Failed to get books for sync", book_ids)
+        return {}
+    end
+
+    return book_ids
 end
 
 return GrimmoryLocalRepository

--- a/grimmory.koplugin/grimmory/settings.lua
+++ b/grimmory.koplugin/grimmory/settings.lua
@@ -34,14 +34,12 @@ local logger = GrimmoryLogger:new()
 ---@field sync_download_directory string
 ---@field sync_reading_sessions boolean
 ---@field sync_reading_progress boolean
----@field synchronized_until number
 ---@field device_id string
 ---@field device_name string
 
 ---@type GrimmorySettingsData
 local DEFAULTS = {
     automatic_check_updates = false,
-    synchronized_until = os.time(), -- plugin init time
     base_uri = "",
     username = "",
     password = "",
@@ -316,16 +314,6 @@ end
 
 function GrimmorySettings:toggleSyncEnableWifi()
     self.data.sync_enable_wifi = not self:getSyncEnableWifi()
-    self:write()
-end
-
-function GrimmorySettings:getSynchronizedUntil()
-    return self.data.synchronized_until or DEFAULTS.synchronized_until
-end
-
----@param timestamp number
-function GrimmorySettings:setSynchronizedUntil(timestamp)
-    self.data.synchronized_until = timestamp
     self:write()
 end
 

--- a/grimmory.koplugin/grimmory/synchronize.lua
+++ b/grimmory.koplugin/grimmory/synchronize.lua
@@ -65,33 +65,67 @@ function GrimmorySynchronize:refreshBooksFromAPI()
     end
 end
 
-function GrimmorySynchronize:synchronizeSessions(callback)
-    if not self.settings:getSyncReadingSessions() then
-        logger:info("Reading sessions sync skipped because feature is disabled")
+---@param book_id integer
+---@param callback function
+function GrimmorySynchronize:pushBookProgress(book_id, callback)
+    if not self.settings:getSyncReadingProgress() then
+        logger:info("Reading progress skipped because feature is disabled for:", book_id)
         return
     end
 
-    local since = self.settings:getSynchronizedUntil()
-    logger:info("Synchronizing sessions since", since)
+    local progress_ok, progress = self.repository:getReadingProgress(book_id)
 
-    local sessions = self.repository:getSessions(since)
+    if progress_ok and progress ~= nil then
+        logger:info("Synchronizing reading progress for:", book_id)
+        local ok = self.reading_progress_manager:pushRemoteProgress(progress)
+
+        if ok then
+            callback({
+                state = "progress-pushed",
+                book_path = progress.book_path,
+                book_md5 = progress.book_md5,
+            })
+
+            self.repository:updateBookSyncTimestamp(book_id, "progress", progress.end_time)
+        else
+            callback({
+                state = "progress-failed",
+                book_path = progress.book_path,
+                book_md5 = progress.book_md5,
+            })
+        end
+    end
+end
+
+---@param book_id integer
+---@param callback function
+function GrimmorySynchronize:pushBookSessions(book_id, callback)
+    if not self.settings:getSyncReadingSessions() then
+        -- Since the reading session sync is disabled, skip them.
+        logger:dbg("Reading sessions skipped because feature is disabled for:", book_id)
+        return
+    end
 
     local threshold_pages = self.settings:getSessionThresholdPages()
     local threshold_seconds = self.settings:getSessionThresholdSeconds()
+
+    logger:info("Synchronizing reading sessions for:", book_id)
+
+    local sessions = self.repository:getPendingSessions(book_id)
 
     for _, session in ipairs(sessions) do
         local total_seconds = session.end_time - session.start_time
         local total_pages = session.end_page - session.start_page + 1
 
         if total_seconds < threshold_seconds then
-            logger:info("Skipped session below time threshold for book", session.book_path)
+            logger:info("Skipped session below time threshold for book", book_id)
             callback({
                 state = "session-skip",
                 bookPath = session.book_path,
                 since = session.end_time,
             })
         elseif total_pages < threshold_pages then
-            logger:info("Skipped session below page threshold for book", session.book_path)
+            logger:info("Skipped session below page threshold for book", book_id)
             callback({
                 state = "session-skip",
                 bookPath = session.book_path,
@@ -110,31 +144,25 @@ function GrimmorySynchronize:synchronizeSessions(callback)
                 session.end_xpointer
             )
 
-            local ok = false
-            local body
-            if session.grimmory_id == nil then
-                body = "Could not match local book to Grimmory"
-            else
-                ok, body = self.api:recordSession(
-                    session.grimmory_id,
-                    session.start_time,
-                    session.end_time,
-                    session.start_progress,
-                    session.end_progress,
-                    session.start_xpointer,
-                    session.end_xpointer
-                )
-            end
+            local ok, body = self.api:recordSession(
+                session.grimmory_id,
+                session.start_time,
+                session.end_time,
+                session.start_progress,
+                session.end_progress,
+                session.start_xpointer,
+                session.end_xpointer
+            )
 
             if ok then
-                logger:info("Session recorded successfully for book", session.book_path)
+                logger:info("Session recorded successfully for book:", book_id)
                 callback({
                     state = "session-recorded",
                     bookPath = session.book_path,
                     since = session.end_time,
                 })
             else
-                logger:err("Session failed recording with error for book: ", session.book_path, " - ", body)
+                logger:err("Session failed recording with error for book: ", book_id, " - ", body)
                 callback({
                     state = "session-error",
                     bookPath = session.book_path,
@@ -142,6 +170,30 @@ function GrimmorySynchronize:synchronizeSessions(callback)
                 })
             end
         end
+
+        self.repository:updateBookSyncTimestamp(book_id, "sessions", session.end_time)
+    end
+end
+
+---@param book_id integer
+---@param callback function
+function GrimmorySynchronize:pushBookMetadata(book_id, callback)
+    self:pushBookProgress(book_id, callback)
+    self:pushBookSessions(book_id, callback)
+end
+
+function GrimmorySynchronize:pushAllPendingBookMetadata(callback)
+    local book_ids = self.repository:getBooksPendingSync(
+        self.settings:getSyncReadingSessions(),
+        self.settings:getSyncReadingProgress()
+    )
+
+    for _, book_id in ipairs(book_ids) do
+        if book_id == nil then
+            break
+        end
+
+        self:pushBookMetadata(book_id, callback)
     end
 end
 
@@ -403,7 +455,7 @@ function GrimmorySynchronize:associateWithShelves(book_path, shelves)
     ReadCollection:write()
 end
 
-function GrimmorySynchronize:synchronizeBooks(callback)
+function GrimmorySynchronize:pullBooks(callback)
     if not self.settings:getSyncShelves() then
         logger:info("Book download skipped because feature is disabled")
         return
@@ -480,29 +532,6 @@ function GrimmorySynchronize:synchronizeBooks(callback)
     end
 end
 
-function GrimmorySynchronize:synchronizeProgress(callback)
-    local reading_progress_records = self.repository:getReadingProgress()
-
-    -- From Koreader to grimmory
-    for _, progress in ipairs(reading_progress_records) do
-        local ok = self.reading_progress_manager:pushRemoteProgress(progress)
-
-        if ok then
-            callback({
-                state = "progress-pushed",
-                book_path = progress.book_path,
-                book_md5 = progress.book_md5,
-            })
-        else
-            callback({
-                state = "progress-failed",
-                book_path = progress.book_path,
-                book_md5 = progress.book_md5,
-            })
-        end
-    end
-end
-
 ---@return boolean ok
 function GrimmorySynchronize:checkForHealthyServer()
     local ok, version = self.api:getServerVersion()
@@ -521,19 +550,21 @@ function GrimmorySynchronize:synchronizeAll(callback)
     end
 
     -- Refresh so we pull fresh books
+    logger:info("Reading books from API")
     self:refreshBooksFromAPI()
 
-    self:synchronizeProgress(callback)
+    -- First, tell Grimmory about all of our reading
+    logger:info("Pushing pending book metadata")
+    self:pushAllPendingBookMetadata(callback)
 
+    -- Then pull the shelves
+    logger:info("Synchronizing shelves")
     self:synchronizeShelves(callback)
 
-    self:synchronizeSessions(callback)
-
-    self:synchronizeBooks(callback)
-
-    logger:info("Highlights not implemented yet")
-
-    logger:info("Personal ratings not implemented yet")
+    -- And only afterwards, pull new books because our
+    -- reading progress may change the books we sync down
+    logger:info("Pulling books")
+    self:pullBooks(callback)
 
     logger:info("Done synchronizing")
 end

--- a/grimmory.koplugin/main.lua
+++ b/grimmory.koplugin/main.lua
@@ -358,11 +358,6 @@ function Grimmory:onGrimmorySync(verbose)
                     pcall(update_callback, indeterminate_progress, 20)
                 end
 
-                if progress.since then
-                    -- Update since
-                    self.settings:setSynchronizedUntil(progress.since)
-                end
-
                 if progress.state == "session-recorded" then
                     session_count = session_count + 1
                 elseif progress.state == "session-error" then


### PR DESCRIPTION
we want to ensure that each book sends sessions and progress only when it's "new" to the server.  we also may eventually want to be able to "hold" specific books from sending various types of data, and then later send them

to accomplish this, the last sync time is stored per-sync-type and per-book in the database and updated as part of the sync

fixes #28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Restructured synchronization workflow to prioritize pushing reading progress and sessions per book before syncing shelves and downloading books.
  * Improved per-book synchronization tracking to ensure reading data is accurately synced.
  * Enhanced reading progress queries for better performance and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory.koplugin/pull/75?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->