### PR TITLE
fix: fail the sync loud if we cannot connect to a valid server

### DIFF
--- a/grimmory.koplugin/grimmory/synchronize.lua
+++ b/grimmory.koplugin/grimmory/synchronize.lua
@@ -546,7 +546,7 @@ end
 
 function GrimmorySynchronize:synchronizeAll(callback)
     if not self:checkForHealthyServer() then
-        return
+        return error("Cannot connect to valid server")
     end
 
     -- Refresh so we pull fresh books

--- a/grimmory.koplugin/main.lua
+++ b/grimmory.koplugin/main.lua
@@ -403,7 +403,7 @@ function Grimmory:onGrimmorySync(verbose)
 
                 if verbose then
                     self.dialog_manager:toast(
-                        _("Failed to Synchronize to Grimmory")
+                        _("Failed to Synchronize with Grimmory")
                     )
                 end
             end


### PR DESCRIPTION
when we cannot connect to a valid server during a sync (eg, cannot connect to host, server is down, wrong credentials) we should fail the sync loud when verbose.  previously, we just bailed early on the sync but instead we should error out.

fixes #72 