### PR TITLE
fix: flush settings before sync to get open book info

### DIFF
--- a/grimmory.koplugin/main.lua
+++ b/grimmory.koplugin/main.lua
@@ -299,6 +299,9 @@ function Grimmory:onGrimmorySyncBackground()
 end
 
 function Grimmory:onGrimmorySync(verbose)
+    -- Tell everything to flush so we have data available for our sync
+    UIManager:broadcastEvent(Event:new("FlushSettings"))
+
     local function sync_callback()
         if not self.wifi_manager:isConnected() then
             logger:err("Cannot sync without connectivity")


### PR DESCRIPTION
when a book is open, it'll keep the values it has in memory for as long as possible to reduce
writes to disk (which may be expensive).  However, for our sync to work we need that data.

this change broadcasts an event picked up by koreader to flush settings to disk

fixes #83