### PR TITLE
feat: pull book progress on initial book download

### DIFF
--- a/grimmory.koplugin/grimmory/doc_metadata.lua
+++ b/grimmory.koplugin/grimmory/doc_metadata.lua
@@ -128,7 +128,7 @@ function DocMetadata:setProgress(path, percent, xpointer, page)
     )
 
     if percent ~= nil then
-        settings:saveSetting("percent_finished", percent)
+        settings:saveSetting("percent_finished", percent / 100)
     else
         settings:delSetting("percent_finished")
     end
@@ -146,20 +146,6 @@ function DocMetadata:setProgress(path, percent, xpointer, page)
     end
 
     settings:flush()
-end
-
----@param path string
----@return number | nil percent
----@return string | nil xpointer
----@return number | nil page
-function DocMetadata:getProgress(path)
-    local settings = self:getDocSettings(path)
-
-    local percent = settings:readSetting("percent_finished")
-    local xpointer = settings:readSetting("last_xpointer")
-    local page = settings:readSetting("last_page")
-
-    return percent, xpointer, page
 end
 
 return DocMetadata

--- a/grimmory.koplugin/grimmory/doc_metadata.lua
+++ b/grimmory.koplugin/grimmory/doc_metadata.lua
@@ -119,6 +119,14 @@ end
 function DocMetadata:setProgress(path, percent, xpointer, page)
     local settings = self:getDocSettings(path)
 
+    -- Hack to prevent us from getting a weird message from koreader
+    -- There may be another way but this seems to be the simplest
+    -- and we only set it if it's not already set.
+    settings:readSetting(
+        "cre_dom_version",
+        settings:readSetting("cre_dom_version", 20200223)
+    )
+
     if percent ~= nil then
         settings:saveSetting("percent_finished", percent)
     else

--- a/grimmory.koplugin/grimmory/grimmory_api.lua
+++ b/grimmory.koplugin/grimmory/grimmory_api.lua
@@ -574,12 +574,17 @@ function GrimmoryAPI:getReadingProgress(username, auth_key, book_md5)
         ["x-auth-key"] = auth_key,
     }
 
-    local ok, _, body = self:request(
+    local ok, code, body = self:request(
         "GET",
         "/api/koreader/syncs/progress/" .. book_md5,
         nil,
         headers
     )
+
+    if code == 404 then
+        -- With a 404 we can just say there's no progress
+        return true, nil
+    end
 
     if not ok or not body or type(body) == "string" then
         logger:err("Unable to read progress for book:", book_md5, "-", body)

--- a/grimmory.koplugin/grimmory/reading/progress_manager.lua
+++ b/grimmory.koplugin/grimmory/reading/progress_manager.lua
@@ -19,6 +19,15 @@ local function compareProgress(progress_a, progress_b)
         return 1
     end
 
+    -- If the two progress values are very close to each other just say they're
+    -- the same.
+    if progress_b.end_xpointer ~= nil and progress_b.end_xpointer == progress_a.end_xpointer then
+        return 0
+    elseif math.abs(progress_b.end_progress - progress_a.end_progress) < 0.01 then
+        return 0
+    end
+
+    -- Otherwise, suggest if newer.
     if progress_a.end_time == progress_b.end_time then
         return 0
     elseif progress_a.end_time < progress_b.end_time then

--- a/grimmory.koplugin/grimmory/reading/progress_manager.lua
+++ b/grimmory.koplugin/grimmory/reading/progress_manager.lua
@@ -65,7 +65,7 @@ function ReadingProgressManager:getLocalProgressForBook(book_path)
         return nil
     end
 
-    if book_path == self.ui.document.file then
+    if self.ui.document and book_path == self.ui.document.file then
         -- This is a bit of a hack to handle the fact that the page event
         -- is fired before the reader is ready.
         -- Look back 30 seconds so the "current" session isn't counted
@@ -173,11 +173,22 @@ function ReadingProgressManager:getRemoteProgressForBook(book_path)
         partial_md5
     )
 
-    if not ok or not progress or type(progress) == "string" then
+    if not ok or type(progress) == "string" then
         self.koreader_auth_id = nil
         self.koreader_auth_secret_md5 = nil
 
         logger:err("Failed to get progress")
+        return nil, nil, nil
+    end
+
+    if progress == nil then
+        -- There's just no progress
+        return nil, nil, nil
+    end
+
+    if type(progress.percentage) ~= "number" then
+        -- This is sometimes a `json.util.null` - perhaps if the record
+        -- exists but has been reset?  The value is `null` in the JSON
         return nil, nil, nil
     end
 
@@ -208,7 +219,7 @@ end
 function ReadingProgressManager:applyProgress(progress)
     -- If book path is the currently open book, use the go to command
     -- DocMetadata -> "last_xpointer" to progress
-    if progress.book_path == self.ui.document.file then
+    if self.ui.document and progress.book_path == self.ui.document.file then
         if self.ui.document.info.has_pages then
             if progress.end_page then
                 self.ui:handleEvent(Event:new("GotoPage", tonumber(progress.end_page)))

--- a/grimmory.koplugin/grimmory/synchronize.lua
+++ b/grimmory.koplugin/grimmory/synchronize.lua
@@ -393,7 +393,11 @@ function GrimmorySynchronize:downloadBook(book_id, download_path)
         return false, message
     end
 
-    self:pullBookProgress(download_path)
+    local progress_ok, progress_result = pcall(self.pullBookProgress, self, download_path)
+
+    if not progress_ok then
+        logger:warn("Could not pull progress for book:", book_id, "-", progress_result)
+    end
 
     return true, nil
 end

--- a/grimmory.koplugin/grimmory/synchronize.lua
+++ b/grimmory.koplugin/grimmory/synchronize.lua
@@ -367,6 +367,18 @@ function GrimmorySynchronize:synchronizeShelves(callback)
     ReadCollection:write()
 end
 
+function GrimmorySynchronize:pullBookProgress(book_path)
+    if not self.settings:getSyncReadingProgress() then
+        return
+    end
+
+    local _, _, progress = self.reading_progress_manager:getRemoteProgressForBook(book_path)
+
+    if progress then
+        self.reading_progress_manager:applyProgress(progress)
+    end
+end
+
 function GrimmorySynchronize:downloadBook(book_id, download_path)
     local success, result, message = pcall(function()
         return self.api:downloadBook(book_id, download_path)
@@ -380,6 +392,8 @@ function GrimmorySynchronize:downloadBook(book_id, download_path)
     if not result then
         return false, message
     end
+
+    self:pullBookProgress(download_path)
 
     return true, nil
 end


### PR DESCRIPTION
when a book is initially downloaded, we should also pull any progress that may exist for the book

fixes #73

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reading progress is automatically pulled and applied when books are downloaded.

* **Bug Fixes**
  * Better handling of missing remote progress (including remote 404s) to avoid false errors.
  * More defensive checks to prevent nil dereferences and ignore invalid remote responses.
  * Improved numeric validation and tolerance for tiny progress differences.
  * Ensures progress-related settings are read to suppress spurious external messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory.koplugin/pull/85?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->