### PR TITLE
fix: rely on progressbardialog's dismiss functionality

### DIFF
--- a/grimmory.koplugin/grimmory/ui/dialog_manager.lua
+++ b/grimmory.koplugin/grimmory/ui/dialog_manager.lua
@@ -380,42 +380,30 @@ end
 
 function DialogManager:showProgressDialog(title, dismiss_callback, dismiss_text)
     local dialog
-    local confirm_dialog
     local is_closing = false
 
     if dismiss_text == nil then
         dismiss_text = _("Terminate this task?")
     end
 
-    local confirm_dismiss = function()
+    local close_callback = function()
+        -- Track this because `dialog:close()` will call this function
         if is_closing then
-            -- The dismiss callback is fired even when
-            -- an outside force is trying to close the
-            -- dialog.
             return
         end
 
-        if confirm_dialog then
-            UIManager:close(confirm_dialog)
-        end
-
-        confirm_dialog = ConfirmBox:new({
-            text = dismiss_text,
-            ok_callback = function()
-                pcall(dismiss_callback)
-                dialog:close()
-            end,
-        })
-
-        UIManager:show(confirm_dialog)
+        is_closing = true
+        pcall(dismiss_callback)
+        dialog:close()
     end
 
     dialog = ProgressbarDialog:new({
         title = _(title),
         progress_max = 100,
         refresh_time_seconds = 3,
+        dismiss_text = dismiss_text,
         dismissable = dismiss_callback ~= nil,
-        dismiss_callback = confirm_dismiss,
+        dismiss_callback = close_callback,
     })
 
     dialog:show()
@@ -423,16 +411,6 @@ function DialogManager:showProgressDialog(title, dismiss_callback, dismiss_text)
     local function update_callback(progress, total_progress)
         dialog.progress_max = total_progress
         dialog:reportProgress(progress)
-    end
-
-    local function close_callback()
-        is_closing = true
-
-        if confirm_dialog then
-            UIManager:close(confirm_dialog)
-        end
-
-        dialog:close()
     end
 
     return update_callback, close_callback

--- a/grimmory.koplugin/main.lua
+++ b/grimmory.koplugin/main.lua
@@ -308,29 +308,25 @@ function Grimmory:onGrimmorySync(verbose)
             return
         end
 
-        local should_terminate = false
-
         if not self:isReadyToSync() then
             return
         end
 
         logger:info("Synchronizing to Grimmory")
 
+        local should_terminate = false
+        local terminated_early = true
+        local queue_terminate = function() should_terminate = true end
+
         self.is_synchronizing = true
-        self.menu:onGrimmorySyncStart(function()
-            self.is_synchronizing = false
-            should_terminate = true
-        end)
+        self.menu:onGrimmorySyncStart(queue_terminate)
 
         local update_callback, close_callback
         if verbose then
             update_callback, close_callback = self.dialog_manager:showProgressDialog(
                 _("Synchronizing to Grimmory"),
-                function()
-                    self.is_synchronizing = false
-                    should_terminate = true
-                end,
-                _("Are you sure you want to interrupt synchronization?")
+                queue_terminate,
+                _("Continue synchronization?")
             )
         end
 
@@ -349,6 +345,7 @@ function Grimmory:onGrimmorySync(verbose)
             end,
             function(progress, terminate)
                 if should_terminate then
+                    terminated_early = true
                     terminate()
                 end
 
@@ -393,7 +390,7 @@ function Grimmory:onGrimmorySync(verbose)
         end
 
         if not ok then
-            if should_terminate then
+            if terminated_early then
                 logger:info("Sync was interrupted by user")
 
                 if verbose then


### PR DESCRIPTION
the "custom" dismiss callback that was previously set up wasn't quite right.  the progressbardialog was closed and then the confirm was shown.

Instead, [the `ProgressBarDialog` can be given dismiss text](https://github.com/koreader/koreader/blob/6ffc7de0d85a2ec767fd0797735f689a1b0e80fd/frontend/ui/widget/progressbardialog.lua#L216) which operates in the same way but doesn't remove the progress bar dialog if you continue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined progress dialog interaction during synchronization operations.
  * Updated synchronization confirmation prompt text for improved clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory.koplugin/pull/87?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->