### PR TITLE
refactor: use paged books endpoint

### DIFF
--- a/grimmory.koplugin/grimmory/grimmory_api.lua
+++ b/grimmory.koplugin/grimmory/grimmory_api.lua
@@ -374,6 +374,30 @@ function GrimmoryAPI:getBooks()
     return ok, books
 end
 
+---@return boolean ok
+---@return Book[] | string
+function GrimmoryAPI:getBooksPage(page_number)
+    local ok, _, body = self:request(
+        "GET",
+        "/api/v1/books/page?sort=addedOn,asc&page=" .. tostring(page_number or 0)
+    )
+
+    if not ok or type(body) == "string" then
+        logger:err("Could not get books", body)
+        return ok, body
+    end
+
+    local books = {}
+
+    if type(body.content) == "table" then
+        for _, raw_book in ipairs(body.content) do
+            table.insert(books, parseBook(raw_book))
+        end
+    end
+
+    return ok, books
+end
+
 function GrimmoryAPI:downloadBook(book_id, destination_path)
     local path = "/api/v1/books/" .. tonumber(book_id) .. "/download"
 

--- a/grimmory.koplugin/grimmory/synchronize.lua
+++ b/grimmory.koplugin/grimmory/synchronize.lua
@@ -24,24 +24,6 @@ function GrimmorySynchronize:new(o)
     return o
 end
 
-function GrimmorySynchronize:refreshBooksFromAPI()
-    local ok, books = self.api:getBooks()
-
-    if not ok or type(books) == "string" then
-        logger:err("Something went wrong fetching books", books)
-        return {}
-    end
-
-    ---@type Book[]
-    self.cached_books = {}
-
-    for _, book in ipairs(books) do
-        if self:isTargetBook(book) then
-            table.insert(self.cached_books, book)
-        end
-    end
-end
-
 ---@param book_id integer
 ---@param callback function
 function GrimmorySynchronize:pushBookProgress(book_id, callback)
@@ -454,6 +436,70 @@ function GrimmorySynchronize:associateWithShelves(book_path, shelves)
     ReadCollection:write()
 end
 
+
+---@param book Book
+---@param callback function
+function GrimmorySynchronize:pullBook(book, callback)
+    local book_exists = false
+
+    if book.primary_file == nil then
+        logger:dbg("Skipping book without file:", book.id)
+        callback({
+            state = "book-skipped",
+            book_id = book.id,
+            download_path = nil,
+        })
+        return
+    end
+
+    local download_path = self:getBookDownloadPath(book)
+
+    -- TODO: Search through known books from collections for this book
+    --       If found, set the `download path to that value.
+
+    if download_path ~= nil and util.fileExists(download_path) then
+        book_exists = true
+    end
+
+    if not book_exists then
+        if download_path ~= nil then
+            logger:dbg("Downloading book", book.id, "to", download_path)
+
+            local ok, message = self:downloadBook(book.id, download_path)
+            if ok then
+                logger:info("Book downloaded:", book.id, " - ", download_path)
+                callback({
+                    state = "book-downloaded",
+                    book_id = book.id,
+                    download_path = download_path,
+                })
+                book_exists = true
+            else
+                logger:err("Book failed download:", book.id, "-", message)
+                callback({
+                    state = "book-error",
+                    book_id = book.id,
+                    download_path = download_path,
+                })
+            end
+        else
+            logger:err("Book skipped as download path could not be found")
+            callback({
+                state = "book-skipped",
+                book_id = book.id,
+                download_path = download_path,
+            })
+        end
+    end
+
+    if book_exists and download_path then
+        -- After we're done, if the book exists we should attach it
+        -- to associated shelves.
+        self:associateWithShelves(download_path, book.shelves)
+        self.repository:upsertBook(download_path, book.id)
+    end
+end
+
 function GrimmorySynchronize:pullBooks(callback)
     if not self.settings:getSyncShelves() then
         logger:info("Book download skipped because feature is disabled")
@@ -473,61 +519,29 @@ function GrimmorySynchronize:pullBooks(callback)
         return
     end
 
-    -- Eventually we should support a "since" but for right
-    -- now it's easiest to sync everything.
-    local books = self.cached_books or {}
+    local page = 0
 
-    -- TODO: Read known books from shelves in case we move the download directory
+    while true do
+        logger:dbg("Fetching books to pull, page:", page)
 
-    for _, book in ipairs(books) do
-        local book_exists = false
+        local books_ok, books_batch = self.api:getBooksPage(page)
 
-        local download_path = self:getBookDownloadPath(book)
-
-        -- TODO: Search through known books from shelves for this book
-        --       If found, set the `download path to that value.
-
-        if download_path ~= nil and util.fileExists(download_path) then
-            book_exists = true
-        end
-
-        if not book_exists then
-            if download_path ~= nil then
-                logger:dbg("Downloading book", book.id, "to", download_path)
-
-                local ok, message = self:downloadBook(book.id, download_path)
-                if ok then
-                    logger:info("Book downloaded:", book.id, " - ", download_path)
-                    callback({
-                        state = "book-downloaded",
-                        book_id = book.id,
-                        download_path = download_path,
-                    })
-                    book_exists = true
-                else
-                    logger:err("Book failed download:", book.id, "-", message)
-                    callback({
-                        state = "book-error",
-                        book_id = book.id,
-                        download_path = download_path,
-                    })
-                end
-            else
-                logger:err("Book skipped as download path could not be found")
-                callback({
-                    state = "book-skipped",
-                    book_id = book.id,
-                    download_path = download_path,
-                })
+        if books_ok and type(books_batch) == "table" then
+            if #books_batch == 0 then
+                break
             end
+
+            for _, book in ipairs(books_batch) do
+                if self:isTargetBook(book) then
+                    self:pullBook(book, callback)
+                end
+            end
+        else
+            logger:info("Something went wrong pulling books, stopping book sync")
+            break
         end
 
-        if book_exists and download_path then
-            -- After we're done, if the book exists we should attach it
-            -- to associated shelves.
-            self:associateWithShelves(download_path, book.shelves)
-            self.repository:upsertBook(download_path, book.id)
-        end
+        page = page + 1
     end
 end
 
@@ -555,10 +569,6 @@ function GrimmorySynchronize:synchronizeAll(callback)
     -- Then pull the shelves
     logger:info("Synchronizing shelves")
     self:synchronizeShelves(callback)
-
-    -- Refresh so we pull fresh books
-    logger:info("Reading books from API")
-    self:refreshBooksFromAPI()
 
     -- And only afterwards, pull new books because our
     -- reading progress may change the books we sync down

--- a/grimmory.koplugin/grimmory/synchronize.lua
+++ b/grimmory.koplugin/grimmory/synchronize.lua
@@ -537,7 +537,7 @@ function GrimmorySynchronize:pullBooks(callback)
                 end
             end
         else
-            logger:info("Something went wrong pulling books, stopping book sync")
+            logger:err("Something went wrong pulling books, stopping book sync")
             break
         end
 


### PR DESCRIPTION
the paged books endpoint may be used to fetch books from a library of an arbitrary size, without having concerns relating to memory constraints on devices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Book library fetching now supports pagination for improved handling of large collections.

* **Refactor**
  * Streamlined book synchronization workflow to use pagination instead of cached batches, enhancing performance and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->