### PR TITLE
fix: prevent non-user sync interrupts from being recorded as such

### DIFF
--- a/grimmory.koplugin/grimmory/synchronize.lua
+++ b/grimmory.koplugin/grimmory/synchronize.lua
@@ -529,6 +529,7 @@ function GrimmorySynchronize:pullBooks(callback)
     local directory_exists, directory_error_message = util.makePath(download_directory)
     if not directory_exists then
         logger:err("Failed to create download directory", directory_error_message)
+        error("Failed to create download directory", directory_error_message)
         return
     end
 

--- a/grimmory.koplugin/main.lua
+++ b/grimmory.koplugin/main.lua
@@ -315,7 +315,7 @@ function Grimmory:onGrimmorySync(verbose)
         logger:info("Synchronizing to Grimmory")
 
         local should_terminate = false
-        local terminated_early = true
+        local terminated_early = false
         local queue_terminate = function() should_terminate = true end
 
         self.is_synchronizing = true
@@ -391,7 +391,7 @@ function Grimmory:onGrimmorySync(verbose)
 
         if not ok then
             if terminated_early then
-                logger:info("Sync was interrupted by user")
+                logger:info("Sync was interrupted by user", result)
 
                 if verbose then
                     self.dialog_manager:toast(


### PR DESCRIPTION
some cases led to a message about user interrupt being the cause of a sync terminating early even when they weren't

this switches the terminate_early to `false` by default, emits an actual error instead of silently succeeding when the directory cannot be made and we cannot pull books at all, and always logs the result even when terminated terminated early

related to #96 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting when synchronization encounters directory creation failures.
  * Enhanced sync interruption detection to correctly distinguish between user cancellations and actual failures, providing more accurate error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->