### PR TITLE
fix: do not associate books with shelves that haven't been pulled

### DIFF
--- a/grimmory.koplugin/grimmory/synchronize.lua
+++ b/grimmory.koplugin/grimmory/synchronize.lua
@@ -423,10 +423,10 @@ function GrimmorySynchronize:associateWithShelves(book_path, shelves)
 
         if shelf_id then
             shelf_id_to_name[tostring(shelf_id)] = collection_name
-        end
 
-        if ReadCollection.coll[collection_name][book_path] ~= nil then
-            local_shelves[collection_name] = true
+            if ReadCollection.coll[collection_name][book_path] ~= nil then
+                local_shelves[collection_name] = true
+            end
         end
     end
 

--- a/grimmory.koplugin/grimmory/synchronize.lua
+++ b/grimmory.koplugin/grimmory/synchronize.lua
@@ -433,11 +433,14 @@ function GrimmorySynchronize:associateWithShelves(book_path, shelves)
     local remote_shelves = {}
     for _, shelf_id in ipairs(shelves) do
         local collection_name = shelf_id_to_name[tostring(shelf_id)]
-        remote_shelves[collection_name] = true
 
-        if collection_name and not local_shelves[collection_name] then
-            logger:dbg("Adding book to collection:", book_path, collection_name)
-            ReadCollection:addItem(book_path, collection_name)
+        if collection_name then
+            remote_shelves[collection_name] = true
+
+            if not local_shelves[collection_name] then
+                logger:dbg("Adding book to collection:", book_path, collection_name)
+                ReadCollection:addItem(book_path, collection_name)
+            end
         end
     end
 


### PR DESCRIPTION
we were trying to associate books with shelves that weren't on the local device - this won't work.  further, if a book was associated with a non-shelf collection, the plugin would attempt to remove that link even though it shouldn't touch non-Grimmory collections

fixes #96

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced local shelf detection during synchronization by refining the logic to ensure shelves are only properly associated when they contain both a valid connection identifier and the required book data. This improves accuracy and consistency of shelf associations across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->