### PR TITLE
fix: terminate background tasks on restart / suspend

### DIFF
--- a/grimmory.koplugin/main.lua
+++ b/grimmory.koplugin/main.lua
@@ -176,6 +176,9 @@ function Grimmory:onPowerOff()
     if self.settings:getSyncOnPowerOff() then
        self:onGrimmorySync(false)
     end
+
+    self.scheduler:clear()
+    self.executor:clear()
 end
 
 function Grimmory:onReaderReady()

--- a/grimmory.koplugin/main.lua
+++ b/grimmory.koplugin/main.lua
@@ -139,6 +139,13 @@ function Grimmory:onExit()
     self.executor:clear()
 end
 
+function Grimmory:onRestart()
+    logger:dbg("Restarting")
+
+    self.scheduler:clear()
+    self.executor:clear()
+end
+
 function Grimmory:onSuspend()
     logger:dbg("Device is suspending")
 
@@ -147,6 +154,8 @@ function Grimmory:onSuspend()
     if self.settings:getSyncOnSuspend() then
        self:onGrimmorySync(false)
     end
+
+    self.executor:clear()
 end
 
 function Grimmory:onResume()


### PR DESCRIPTION
on suspend or restart we should stop background tasks - otherwise unexpected behaviors may occur

on restart, it will lead to a background task that is completely un-controlled; on suspend and resume, there's undefined behavior that can happen

fixes #95

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin lifecycle management with proper restart handling and state cleanup during suspension for better stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->