### PR TITLE
chore: handle higher message throughput before handing back to UI

### DIFF
--- a/grimmory.koplugin/grimmory/executor.lua
+++ b/grimmory.koplugin/grimmory/executor.lua
@@ -193,7 +193,7 @@ function GrimmoryExecutor:run(runnable, on_progress)
 
                 messages_received = messages_received + 1
 
-                if messages_received > 3 then
+                if messages_received > 100 then
                     -- If we keep receiving messages we should hand
                     -- back to the UI thread for a bit.
                     break


### PR DESCRIPTION
if we only push 3 messages, higher counts of messages (such as with books) means we delay "ending" the sync because we are still buffering messages.  moving this to 100 messages ups the throughput significantly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized message processing efficiency to reduce UI thread interruptions during sustained subprocess message reception, improving overall responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->