### PR TITLE
feat: support pushing singular / open books

### DIFF
--- a/grimmory.koplugin/grimmory/synchronize.lua
+++ b/grimmory.koplugin/grimmory/synchronize.lua
@@ -619,4 +619,30 @@ function GrimmorySynchronize:synchronizeAll(callback)
     logger:info("Done synchronizing")
 end
 
+function GrimmorySynchronize:synchronizeBook(book_path, callback)
+    if not self:checkForHealthyServer() then
+        error("Cannot connect to valid server")
+    end
+
+    -- Get book ID
+    local book_ok, book_id = self.repository:upsertBook(book_path)
+
+    if not book_ok or not book_id then
+        error("Could not track book")
+    end
+
+    -- First, tell Grimmory about all of our reading
+    logger:info("Pushing pending book metadata:", book_path)
+    self:pushBookMetadata(book_id, callback)
+
+    -- Then, try to get progress
+    local progress_ok, progress_result = pcall(self.pullBookProgress, self, book_path)
+
+    if not progress_ok then
+        logger:warn("Could not pull progress for book:", book_path, "-", progress_result)
+    end
+
+    logger:info("Done synchronizing book:", book_path)
+end
+
 return GrimmorySynchronize

--- a/grimmory.koplugin/grimmory/synchronize.lua
+++ b/grimmory.koplugin/grimmory/synchronize.lua
@@ -635,6 +635,13 @@ function GrimmorySynchronize:synchronizeBook(book_path, callback)
     logger:info("Pushing pending book metadata:", book_path)
     self:pushBookMetadata(book_id, callback)
 
+    callback({
+        state = "push-book-metadata",
+        book_id = book_id,
+        pushed_books = 1,
+        total_books = 1,
+    })
+
     -- Then, try to get progress
     local progress_ok, progress_result = pcall(self.pullBookProgress, self, book_path)
 

--- a/grimmory.koplugin/grimmory/ui/menu.lua
+++ b/grimmory.koplugin/grimmory/ui/menu.lua
@@ -11,6 +11,7 @@ local GrimmoryLogger = require("grimmory/logger")
 local logger = GrimmoryLogger:new()
 
 ---@class GrimmoryMenu
+---@field ui any This is a ReaderUI
 ---@field settings GrimmorySettings
 ---@field dialog_manager DialogManager
 ---@field updater GrimmorySelfUpdater
@@ -238,14 +239,9 @@ function GrimmoryMenu:getTopMenu()
         table.insert(
             menu, 1,
             {
-                text = _("Force Sync Now"),
+                text = _("Sync Everything Now"),
                 enabled_func = function()
-                    if self.settings:getBaseUri() == "" then
-                        logger:info("BaseURI is not configured, cannot sync")
-                        return false
-                    end
-
-                    return true
+                    return self.settings:getBaseUri() ~= ""
                 end,
                 callback = function()
                     UIManager:broadcastEvent(Event:new("GrimmorySync", true))
@@ -270,6 +266,21 @@ function GrimmoryMenu:getTopMenu()
                     end
                 end,
                 separator = true,
+            }
+        )
+    end
+
+    if self.ui ~= nil and self.ui.document ~= nil then
+        table.insert(
+            menu, 1,
+            {
+                text = _("Sync Open Book Now"),
+                enabled_func = function()
+                    return self.settings:getBaseUri() ~= "" and self.interrupt_sync == nil
+                end,
+                callback = function()
+                    UIManager:broadcastEvent(Event:new("GrimmorySyncOpenBook", true))
+                end,
             }
         )
     end

--- a/grimmory.koplugin/main.lua
+++ b/grimmory.koplugin/main.lua
@@ -123,6 +123,7 @@ function Grimmory:init()
     })
 
     self.menu = GrimmoryMenu:new({
+        ui = self.ui,
         settings = self.settings,
         dialog_manager = self.dialog_manager,
         updater = self.updater,

--- a/grimmory.koplugin/main.lua
+++ b/grimmory.koplugin/main.lua
@@ -7,6 +7,7 @@ local _ = require("gettext")
 local T = require("ffi/util").template
 
 local Dispatcher = require("dispatcher")
+local FileManager = require("apps/filemanager/filemanager")
 local UIManager = require("ui/uimanager")
 local Event = require("ui/event")
 local ReadCollection = require("readcollection")
@@ -126,6 +127,30 @@ function Grimmory:init()
     self:onGrimmorySettingsChanged()
 
     self.ui.menu:registerToMainMenu(self.menu)
+
+    FileManager:addFileDialogButtons(
+        "grimmory_actions",
+        function(file, is_file)
+            if not is_file then
+                return nil
+            end
+
+            return {
+                {
+                    text = _("Sync with Grimmory"),
+                    callback = function()
+                        local file_chooser = FileManager.instance.file_chooser
+
+                        if file_chooser and file_chooser.file_dialog then
+                            UIManager:close(file_chooser.file_dialog)
+                        end
+
+                        self:onGrimmorySync(true, file)
+                    end,
+                },
+            }
+        end
+    )
 
     self:onDispatcherRegisterActions()
 
@@ -298,7 +323,7 @@ function Grimmory:onGrimmorySyncBackground()
     return self:onGrimmorySync(false)
 end
 
-function Grimmory:onGrimmorySync(verbose)
+function Grimmory:onGrimmorySync(verbose, book_path)
     -- Tell everything to flush so we have data available for our sync
     UIManager:broadcastEvent(Event:new("FlushSettings"))
 
@@ -353,7 +378,11 @@ function Grimmory:onGrimmorySync(verbose)
 
         local ok, result = self.executor:run(
             function(progress_callback)
-                self.synchronizer:synchronizeAll(progress_callback)
+                if book_path then
+                    self.synchronizer:synchronizeBook(book_path, progress_callback)
+                else
+                    self.synchronizer:synchronizeAll(progress_callback)
+                end
             end,
             function(progress, terminate)
                 if should_terminate then

--- a/grimmory.koplugin/main.lua
+++ b/grimmory.koplugin/main.lua
@@ -62,6 +62,20 @@ function Grimmory:onDispatcherRegisterActions()
     title = _("Grimmory: Sync in Background"),
     general = true,
   })
+
+  Dispatcher:registerAction("grimmory_sync_open_book_foreground", {
+    category = "none",
+    event = "GrimmorySyncOpenBookForeground",
+    title = _("Grimmory: Sync Open Book Now"),
+    general = true,
+  })
+
+  Dispatcher:registerAction("grimmory_sync_open_book_background", {
+    category = "none",
+    event = "GrimmorySyncOpenBookBackground",
+    title = _("Grimmory: Sync Open Book in Background"),
+    general = true,
+  })
 end
 
 function Grimmory:init()
@@ -178,7 +192,7 @@ function Grimmory:onResume()
     logger:dbg("Device is resuming")
 
     if self.settings:getSyncReadingProgress() then
-        self:syncProgressForOpenBook()
+        self:pullProgressForOpenBook()
     end
 
     self.reading_recorder:onSessionStart()
@@ -198,7 +212,7 @@ function Grimmory:onReaderReady()
     logger:dbg("Document open and ready")
 
     if self.settings:getSyncReadingProgress() then
-        self:syncProgressForOpenBook()
+        self:pullProgressForOpenBook()
     end
 
     self.reading_recorder:onSessionStart()
@@ -270,7 +284,7 @@ function Grimmory:onSchedulePeriodicPush()
     end
 end
 
-function Grimmory:syncProgressForOpenBook()
+function Grimmory:pullProgressForOpenBook()
     if self.ui == nil or self.ui.document == nil or self.ui.document.file == nil then
         return
     end
@@ -321,6 +335,25 @@ end
 
 function Grimmory:onGrimmorySyncBackground()
     return self:onGrimmorySync(false)
+end
+
+function Grimmory:onGrimmorySyncOpenBookForeground()
+    return self:onGrimmorySyncOpenBook(true)
+end
+
+function Grimmory:onGrimmorySyncOpenBookBackground()
+    return self:onGrimmorySyncOpenBook(false)
+end
+
+function Grimmory:onGrimmorySyncOpenBook(verbose)
+    if self.ui == nil or self.ui.document == nil or self.ui.document.file == nil then
+        logger:info("No open book, skipping sync")
+        return
+    end
+
+    local book_path = self.ui.document.file
+
+    return self:onGrimmorySync(verbose, book_path)
 end
 
 function Grimmory:onGrimmorySync(verbose, book_path)


### PR DESCRIPTION
adds "sync with grimmory" to file manager dialog, adds an action for syncing the open book, & adds a grimmory sync menu when reading a book

<img width="400" alt="image" src="https://github.com/user-attachments/assets/18659f9a-a464-4eee-8809-09dd502b38cc" />


<img width="400" alt="image" src="https://github.com/user-attachments/assets/0ce8dfe0-b15a-4344-a9fd-b89190bfb057" />

fixes #77

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quickly sync your currently open book without syncing all books
  * Sync individual books directly from the file manager selection dialog
  * Choose foreground or background sync for the open book
  * Sync now option added to the top menu when a book is open
  * Sync attempts will pull reading progress from the server for the synced book

* **UI Changes**
  * Renamed "Force Sync Now" to "Sync Everything Now" and simplified enablement logic
<!-- end of auto-generated comment: release notes by coderabbit.ai -->