### PR TITLE
chore: change session logic to match user request

### DIFF
--- a/grimmory.koplugin/grimmory/repository.lua
+++ b/grimmory.koplugin/grimmory/repository.lua
@@ -523,12 +523,10 @@ function GrimmoryLocalRepository:getPendingSessions(book_id)
                 collapsedSession = true
                 sessions[#sessions].end_time = math.max(event.timestamp, sessions[#sessions].end_time)
 
-                -- If the "progress" is further
-                if read_progress > sessions[#sessions].end_progress then
-                    sessions[#sessions].end_page = event.page
-                    sessions[#sessions].end_progress = read_progress
-                    sessions[#sessions].end_xpointer = event.xpointer
-                end
+                -- se tthe values to whatever the last event has
+                sessions[#sessions].end_page = event.page
+                sessions[#sessions].end_progress = read_progress
+                sessions[#sessions].end_xpointer = event.xpointer
             end
         end
 

--- a/grimmory.koplugin/grimmory/repository.lua
+++ b/grimmory.koplugin/grimmory/repository.lua
@@ -521,9 +521,9 @@ function GrimmoryLocalRepository:getPendingSessions(book_id)
             if isPartOfSession(sessions[#sessions], event) then
                 logger:dbg("Collapsed session for book", event.book_md5)
                 collapsedSession = true
-                sessions[#sessions].end_time = math.max(event.timestamp, sessions[#sessions].end_time)
 
-                -- se tthe values to whatever the last event has
+                -- set the end of this session to whatever the last event is
+                sessions[#sessions].end_time = event.timestamp
                 sessions[#sessions].end_page = event.page
                 sessions[#sessions].end_progress = read_progress
                 sessions[#sessions].end_xpointer = event.xpointer


### PR DESCRIPTION
Two users requested this behavior change - that the session always uses the latest value no matter what.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pending session tracking to ensure session endpoint data is consistently updated with incoming events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->