### PR TITLE
fix: push pages as location to sessions rather than xpointer

### DIFF
--- a/grimmory.koplugin/grimmory/synchronize.lua
+++ b/grimmory.koplugin/grimmory/synchronize.lua
@@ -99,8 +99,8 @@ function GrimmorySynchronize:pushBookSessions(book_id, callback)
                 session.end_time,
                 session.start_progress,
                 session.end_progress,
-                session.start_xpointer,
-                session.end_xpointer
+                session.start_page,
+                session.end_page
             )
 
             local ok, body = self.api:recordSession(
@@ -109,8 +109,8 @@ function GrimmorySynchronize:pushBookSessions(book_id, callback)
                 session.end_time,
                 session.start_progress,
                 session.end_progress,
-                session.start_xpointer,
-                session.end_xpointer
+                tostring(session.start_page),
+                tostring(session.end_page)
             )
 
             if ok then


### PR DESCRIPTION
Grimmory expects page information to be pushed for reading sessions rather than xpointers.  This updates the reading session sync to push the correct values.

fixes #113

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session synchronization now records session boundaries using page numbers instead of position markers for more reliable tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->