### PR TITLE
refactor: better naming for repo `findBookByGrimmoryId`

### DIFF
--- a/grimmory.koplugin/grimmory/repository.lua
+++ b/grimmory.koplugin/grimmory/repository.lua
@@ -213,7 +213,7 @@ end
 ---@return boolean ok
 ---@return string | nil book_path
 ---@return string | nil book_md5
-function GrimmoryLocalRepository:getBookInfo(grimmory_id)
+function GrimmoryLocalRepository:findBookByGrimmoryId(grimmory_id)
     local ok, book = self:withDatabase(
         function(conn)
             local select_stmt = conn:prepare([[

--- a/grimmory.koplugin/grimmory/synchronize.lua
+++ b/grimmory.koplugin/grimmory/synchronize.lua
@@ -372,7 +372,7 @@ end
 ---@param book Book
 ---@return string | nil download_path
 function GrimmorySynchronize:getBookDownloadPath(book)
-    local existing_book_ok, existing_book_path = self.repository:getBookInfo(book.id)
+    local existing_book_ok, existing_book_path = self.repository:findBookByGrimmoryId(book.id)
     if existing_book_ok and existing_book_path then
         return existing_book_path
     end


### PR DESCRIPTION
rename `getBookInfo` to be `findBookByGrimmoryId` which is less confusing