### PR TITLE
fix: properly persist sync on close document

### DIFF
--- a/grimmory.koplugin/grimmory/settings.lua
+++ b/grimmory.koplugin/grimmory/settings.lua
@@ -276,6 +276,7 @@ end
 
 function GrimmorySettings:toggleSyncOnCloseDocument()
     self.data.sync_on_close_document = not self:getSyncOnCloseDocument()
+    self:write()
 end
 
 function GrimmorySettings:getSyncOnSuspend()


### PR DESCRIPTION
this setting was missing `write`