### PR TITLE
feat: sync annotations with grimmory

### DIFF
--- a/grimmory.koplugin/grimmory/doc_metadata.lua
+++ b/grimmory.koplugin/grimmory/doc_metadata.lua
@@ -217,4 +217,73 @@ function DocMetadata:setProgress(path, percent, xpointer, page)
     settings:flush()
 end
 
+function DocMetadata:getAnnotations(path)
+    local settings = self:getDocSettings(path)
+
+    return settings:readSetting("annotations") or {}
+end
+
+function DocMetadata:setAnnotations(path, annotations)
+    local settings = self:getDocSettings(path)
+
+    settings:saveSetting("annotations_externally_modified", true)
+    settings:saveSetting("annotations", annotations)
+
+    settings:flush()
+end
+
+---@param book_path string
+---@return integer[]
+function DocMetadata:getModifiedGrimmoryAnnotations(path)
+    local settings = self:getDocSettings(path)
+
+    return settings:readSetting("modified_grimmory_annotations") or {}
+end
+
+---@param book_path string
+---@param grimmory_id integer
+function DocMetadata:removeModifiedGrimmoryAnnotation(path, grimmory_id)
+    local settings = self:getDocSettings(path)
+    local existing_grimmory_ids = settings:readSetting("modified_grimmory_annotations") or {}
+
+    local new_grimmory_ids = {}
+    for _, v in ipairs(existing_grimmory_ids) do
+        if v ~= grimmory_id then
+            table.insert(new_grimmory_ids, v)
+        end
+    end
+
+    if #new_grimmory_ids == #existing_grimmory_ids then
+        -- No change, skip save
+        return
+    end
+
+    if #new_grimmory_ids == 0 then
+        settings:delSetting("modified_grimmory_annotations")
+    else
+        settings:saveSetting("modified_grimmory_annotations", new_grimmory_ids)
+    end
+
+    settings:flush()
+end
+
+---@param book_path string
+---@param grimmory_id integer
+function DocMetadata:appendModifiedGrimmoryAnnotation(path, grimmory_id)
+    local settings = self:getDocSettings(path)
+    local grimmory_ids = settings:readSetting("modified_grimmory_annotations") or {}
+
+    for _, v in ipairs(grimmory_ids) do
+        if v == grimmory_id then
+            -- Already exists, skip everything else.
+            return
+        end
+    end
+
+    table.insert(grimmory_ids, grimmory_id)
+
+    settings:saveSetting("modified_grimmory_annotations", grimmory_ids)
+    settings:flush()
+end
+
 return DocMetadata

--- a/grimmory.koplugin/grimmory/grimmory_api.lua
+++ b/grimmory.koplugin/grimmory/grimmory_api.lua
@@ -753,16 +753,16 @@ function GrimmoryAPI:getAnnotations(book_id)
     for _, raw_annotation in ipairs(body) do
         ---@type GrimmoryAnnotation
         local annotation = {
-            id = tonumber(raw_annotation.id) or 0,
-            book_id = tonumber(raw_annotation.bookId) or 0,
-            created_at = fromISO8601(raw_annotation.createdAt),
-            updated_at = fromISO8601(raw_annotation.updatedAt),
-            cfi = tostring(raw_annotation.cfi),
-            text = tostring(raw_annotation.text),
-            note = tostring(raw_annotation.note),
-            chapter = tostring(raw_annotation.chapterTitle),
-            color = tostring(raw_annotation.color),
-            style = tostring(raw_annotation.style),
+            id = from_json_number(raw_annotation.id) or 0,
+            book_id = from_json_number(raw_annotation.bookId) or 0,
+            created_at = from_json_iso8601(raw_annotation.createdAt),
+            updated_at = from_json_iso8601(raw_annotation.updatedAt),
+            cfi = from_json_string(raw_annotation.cfi),
+            text = from_json_string(raw_annotation.text),
+            note = from_json_string(raw_annotation.note),
+            chapter = from_json_string(raw_annotation.chapterTitle),
+            color = from_json_string(raw_annotation.color),
+            style = from_json_string(raw_annotation.style),
         }
 
         table.insert(annotations, annotation)

--- a/grimmory.koplugin/grimmory/grimmory_api.lua
+++ b/grimmory.koplugin/grimmory/grimmory_api.lua
@@ -96,6 +96,17 @@ end
 ---@field metadata BookMetadata
 ---@field primary_file BookFile | nil
 
+---@class GrimmoryAnnotation
+---@field id number | nil
+---@field book_id number
+---@field created_at number
+---@field updated_at number | nil
+---@field cfi string
+---@field text string
+---@field chapter string
+---@field color string
+---@field style string
+
 local function parse_book(book)
     local shelves = {}
 
@@ -720,6 +731,129 @@ function GrimmoryAPI:getReadingProgress(username, auth_key, book_md5)
     }
 
     return ok, progress
+end
+
+---@param book_id number
+---@return boolean ok
+---@return GrimmoryAnnotation[] annotations
+function GrimmoryAPI:getAnnotations(book_id)
+    local ok, _, body = self:request(
+        "GET",
+        "/api/v1/annotations/book/" .. tostring(book_id)
+    )
+
+    if not ok or not body or type(body) == "string" then
+        logger:err("Unable to read annotations for book:", book_id, "-", body)
+        return false, {}
+    end
+
+    local annotations = {}
+
+    for _, raw_annotation in ipairs(body) do
+        ---@type GrimmoryAnnotation
+        local annotation = {
+            id = tonumber(raw_annotation.id) or 0,
+            book_id = tonumber(raw_annotation.bookId) or 0,
+            created_at = fromISO8601(raw_annotation.createdAt),
+            cfi = tostring(raw_annotation.cfi),
+            text = tostring(raw_annotation.text),
+            chapter = tostring(raw_annotation.chapterTitle),
+            color = tostring(raw_annotation.color),
+            style = tostring(raw_annotation.style),
+        }
+
+        table.insert(annotations, annotation)
+    end
+
+    return ok, annotations
+end
+
+---@param book_id number
+---@param cfi string
+---@param chapter_title string
+---@param text string
+---@param color string
+---@param style string
+---@param note string | nil
+function GrimmoryAPI:createAnnotation(
+    book_id,
+    cfi,
+    chapter_title,
+    text,
+    color,
+    style,
+    note
+)
+    local request = {
+        bookId = book_id,
+        cfi = cfi,
+        chapterTitle = chapter_title,
+        text = text,
+        color = color,
+        style = style,
+        note = note,
+    }
+
+    local ok, _, body = self:request(
+        "POST",
+        "/api/v1/annotations",
+        request
+    )
+
+    if not ok then
+        logger:err("Unable to push annotation", body)
+        return false, nil
+    end
+
+    return ok, body
+end
+
+---@param annotation_id number
+function GrimmoryAPI:deleteAnnotation(
+    annotation_id
+)
+    local ok, code, body = self:request(
+        "DELETE",
+        "/api/v1/annotations/" .. annotation_id
+    )
+
+    if not ok and code ~= 404 then
+        logger:err("Unable to delete annotation", body)
+        return false
+    end
+
+    return true
+
+end
+
+---@param annotation_id number
+---@param color string
+---@param style string
+---@param note string | nil
+function GrimmoryAPI:updateAnnotation(
+    annotation_id,
+    color,
+    style,
+    note
+)
+    local request = {
+        color = color,
+        style = style,
+        note = note,
+    }
+
+    local ok, _, body = self:request(
+        "PUT",
+        "/api/v1/annotations/" .. annotation_id,
+        request
+    )
+
+    if not ok then
+        logger:err("Unable to update annotation", body)
+        return false
+    end
+
+    return ok
 end
 
 return GrimmoryAPI

--- a/grimmory.koplugin/grimmory/grimmory_api.lua
+++ b/grimmory.koplugin/grimmory/grimmory_api.lua
@@ -756,6 +756,7 @@ function GrimmoryAPI:getAnnotations(book_id)
             id = tonumber(raw_annotation.id) or 0,
             book_id = tonumber(raw_annotation.bookId) or 0,
             created_at = fromISO8601(raw_annotation.createdAt),
+            updated_at = fromISO8601(raw_annotation.updatedAt),
             cfi = tostring(raw_annotation.cfi),
             text = tostring(raw_annotation.text),
             note = tostring(raw_annotation.note),

--- a/grimmory.koplugin/grimmory/grimmory_api.lua
+++ b/grimmory.koplugin/grimmory/grimmory_api.lua
@@ -103,6 +103,7 @@ end
 ---@field updated_at number | nil
 ---@field cfi string
 ---@field text string
+---@field note string | nil
 ---@field chapter string
 ---@field color string
 ---@field style string
@@ -757,6 +758,7 @@ function GrimmoryAPI:getAnnotations(book_id)
             created_at = fromISO8601(raw_annotation.createdAt),
             cfi = tostring(raw_annotation.cfi),
             text = tostring(raw_annotation.text),
+            note = tostring(raw_annotation.note),
             chapter = tostring(raw_annotation.chapterTitle),
             color = tostring(raw_annotation.color),
             style = tostring(raw_annotation.style),

--- a/grimmory.koplugin/grimmory/reading/annotations.lua
+++ b/grimmory.koplugin/grimmory/reading/annotations.lua
@@ -124,6 +124,10 @@ function GrimmoryReadingAnnotations:new(doc_metadata)
 end
 
 local function normalize_xpointer(xpointer)
+    if xpointer == nil then
+        return ""
+    end
+
     -- /p[1]/ -> /p/
     xpointer = xpointer:gsub("%[1%]", "")
 
@@ -170,6 +174,8 @@ local function merge_annotations(local_annotations, remote_annotations)
             for _, existing_annotation in ipairs(new_annotations) do
                 if (
                     existing_annotation.grimmory_id == nil and
+                    existing_annotation.pos0 ~= nil and
+                    existing_annotation.pos1 ~= nil and
                     is_same_xpointer(existing_annotation.pos0, annotation.pos0) and
                     is_same_xpointer(existing_annotation.pos1, annotation.pos1)
                 ) then
@@ -269,20 +275,24 @@ function GrimmoryReadingAnnotations:getAnnotations(book_path)
         book_path,
         function(cfi_resolver)
             for _, annotation in ipairs(annotations) do
-                ---@type GrimmoryAnnotation
-                local grimmory_annotation = {
-                    id = annotation.grimmory_id,
-                    book_id = -1,
-                    created_at = from_annotation_datetime(annotation.datetime),
-                    updated_at = from_annotation_datetime(annotation.datetime_updated),
-                    cfi = cfi_resolver:xpointerRangeToCFI(annotation.pos0, annotation.pos1),
-                    chapter = annotation.chapter,
-                    text = annotation.text,
-                    color = KOREADER_COLOR_MAP[annotation.color] or DEFAULT_GRIMMORY_COLOR,
-                    style = KOREADER_STYLE_MAP[annotation.drawer] or DEFAULT_GRIMMORY_STYLE,
-                }
+                -- Annotations without pos0 / pos1 are bookmarks
+                if annotation.pos0 ~= nil and annotation.pos1 ~= nil then
+                    ---@type GrimmoryAnnotation
+                    local grimmory_annotation = {
+                        id = annotation.grimmory_id,
+                        book_id = -1,
+                        created_at = from_annotation_datetime(annotation.datetime),
+                        updated_at = from_annotation_datetime(annotation.datetime_updated),
+                        cfi = cfi_resolver:xpointerRangeToCFI(annotation.pos0, annotation.pos1),
+                        chapter = annotation.chapter,
+                        text = annotation.text,
+                        note = annotation.note,
+                        color = KOREADER_COLOR_MAP[annotation.color] or DEFAULT_GRIMMORY_COLOR,
+                        style = KOREADER_STYLE_MAP[annotation.drawer] or DEFAULT_GRIMMORY_STYLE,
+                    }
 
-                table.insert(grimmory_annotations, grimmory_annotation)
+                    table.insert(grimmory_annotations, grimmory_annotation)
+                end
             end
         end
     )

--- a/grimmory.koplugin/grimmory/reading/annotations.lua
+++ b/grimmory.koplugin/grimmory/reading/annotations.lua
@@ -1,0 +1,293 @@
+local DocumentRegistry = require("document/documentregistry")
+
+local GrimmoryCFIResolver = require("grimmory/cfi_resolver")
+
+
+---@param value integer
+---@return string
+local function to_annotation_datetime(value)
+    if value == nil then
+        return nil
+    end
+
+    local parsed = os.date("!*t", value)
+    return string.format(
+        "%04d-%02d-%02d %02d:%02d:%02dZ",
+        parsed.year,
+        parsed.month,
+        parsed.day,
+        parsed.hour,
+        parsed.min,
+        parsed.sec
+    )
+end
+
+---@param value string
+---@return integer timestamp
+local function from_annotation_datetime(value)
+    if value == nil then
+        return nil
+    end
+
+    local year, month, day, hour, min, sec = value:match(
+        "(%d+)-(%d+)-(%d+) (%d+):(%d+):(%d+)"
+    )
+
+    return os.time({
+        year = year,
+        month = month,
+        day = day,
+        hour = hour,
+        min = min,
+        sec = sec
+    })
+end
+
+---@param document_path string
+---@param callback (fun(resolver: GrimmoryCFIResolver): nil)
+local function with_cfi_resolver(document_path, callback)
+    local document = (
+        DocumentRegistry:hasProvider(document_path) and
+        DocumentRegistry:openDocument(document_path)
+    )
+
+    if document then
+        local loaded = true
+        if document.loadDocument then
+            loaded = document:loadDocument(true)
+        end
+
+        if loaded then
+            local cfi_resolver = GrimmoryCFIResolver:new(document)
+
+            callback(cfi_resolver)
+        end
+
+        document:close()
+    end
+end
+
+local KOREADER_COLOR_MAP = {
+    yellow = "#FFC107",
+    green = "#4ADE80",
+    cyan = "#38BDF8",
+    pink = "#F472B6",
+    orange = "#FB923C",
+    red = "#FB523C",
+    purple = "#F452FC",
+    blue = "#0248F8",
+    gray = "#AAAAAA",
+    white = "#FAFAFA",
+}
+
+local GRIMMORY_COLOR_MAP = {
+    ["#FFC107"] = "yellow",
+    ["#4ADE80"] = "green",
+    ["#38BDF8"] = "cyan",
+    ["#F472B6"] = "pink",
+    ["#FB923C"] = "orange",
+    ["#FB523C"] = "red",
+    ["#F452FC"] = "purple",
+    ["#0248F8"] = "blue",
+    ["#AAAAAA"] = "gray",
+    ["#FAFAFA"] = "white",
+}
+
+local KOREADER_STYLE_MAP = {
+    lighten    = "highlight",
+    underscore = "underline",
+    strikeout  = "strikethrough",
+}
+
+local GRIMMORY_STYLE_MAP = {
+    highlight = "lighten",
+    underline = "underscore",
+    strikethrough = "strikeout",
+}
+
+local DEFAULT_KOREADER_COLOR = "yellow"
+local DEFAULT_KOREADER_STYLE = "lighten"
+local DEFAULT_GRIMMORY_COLOR = KOREADER_COLOR_MAP[DEFAULT_KOREADER_COLOR]
+local DEFAULT_GRIMMORY_STYLE = KOREADER_STYLE_MAP[DEFAULT_KOREADER_STYLE]
+
+---@class GrimmoryReadingAnnotations
+---@field doc_metadata GrimmoryDocMetadata
+local GrimmoryReadingAnnotations = {}
+
+function GrimmoryReadingAnnotations:new(doc_metadata)
+    local o = {
+        doc_metadata = doc_metadata,
+    }
+    setmetatable(o, self)
+    self.__index = self
+    return o
+end
+
+local function normalize_xpointer(xpointer)
+    -- /p[1]/ -> /p/
+    xpointer = xpointer:gsub("%[1%]", "")
+
+    -- /text().0 -> /text()
+    xpointer = xpointer:gsub("%.0$", "")
+
+    return xpointer
+end
+
+---@param a string
+---@param b string
+---@return bool
+local function is_same_xpointer(a, b)
+    return normalize_xpointer(a) == normalize_xpointer(b)
+end
+
+---@param book_path string
+local function merge_annotations(local_annotations, remote_annotations)
+    local remote_grimmory_ids = {}
+    for _, a in ipairs(remote_annotations) do
+        if a.grimmory_id ~= nil then
+            remote_grimmory_ids[tostring(a.grimmory_id)] = a
+        end
+    end
+
+    local local_grimmory_ids = {}
+    local new_annotations = {}
+
+    -- Filter out existing records with Grimmory IDs that do not
+    -- exist on the Grimmory side anymore.
+    for _, a in ipairs(local_annotations) do
+        if a.grimmory_id ~= nil then
+            local_grimmory_ids[tostring(a.grimmory_id)] = a
+        end
+
+        if a.grimmory_id == nil or remote_grimmory_ids[tostring(a.grimmory_id)] then
+            table.insert(new_annotations, a)
+        end
+    end
+
+    for grimmory_id, annotation in pairs(remote_grimmory_ids) do
+        if local_grimmory_ids[grimmory_id] == nil then
+            local found_annotation = false
+            for _, existing_annotation in ipairs(new_annotations) do
+                if (
+                    existing_annotation.grimmory_id == nil and
+                    is_same_xpointer(existing_annotation.pos0, annotation.pos0) and
+                    is_same_xpointer(existing_annotation.pos1, annotation.pos1)
+                ) then
+                    found_annotation = true
+
+                    -- Just apply, don't think too hard about it.
+                    existing_annotation.grimmory_id = annotation.grimmory_id
+                    existing_annotation.datetime = annotation.datetime
+                    existing_annotation.datetime_updated = annotation.datetime_updated
+                    existing_annotation.color = annotation.color
+                    existing_annotation.drawer = annotation.drawer
+                    existing_annotation.chapter = annotation.chapter
+                    existing_annotation.text = annotation.text
+                    existing_annotation.page = annotation.page
+                end
+            end
+
+            if not found_annotation then
+                -- This is a new annotation and can be added to the table
+                table.insert(new_annotations, annotation)
+            end
+        else
+            -- Apply to matching grimmory ID
+            local existing_annotation = local_grimmory_ids[grimmory_id]
+
+            existing_annotation.pos0 = annotation.pos0
+            existing_annotation.pos1 = annotation.pos1
+            existing_annotation.datetime = annotation.datetime
+            existing_annotation.datetime_updated = annotation.datetime_updated
+            existing_annotation.color = annotation.color
+            existing_annotation.drawer = annotation.drawer
+            existing_annotation.chapter = annotation.chapter
+            existing_annotation.text = annotation.text
+            existing_annotation.page = annotation.page
+        end
+    end
+
+    -- TODO: Merge overlapping annotations
+    -- If there are annotations that overlap exactly, select the "latest"
+    -- and delete the older ones
+    -- For imperfect overlap, combine and prioritize the later ones.
+
+    return new_annotations
+end
+
+---@param book_path string
+---@param annotations GrimmoryAnnotation[]
+function GrimmoryReadingAnnotations:applyAnnotations(book_path, grimmory_annotations)
+    local remote_annotations = {}
+
+    with_cfi_resolver(
+        book_path,
+        function (cfi_resolver)
+            for _, annotation in ipairs(grimmory_annotations) do
+                local xpointer_start, xpointer_end = cfi_resolver:cfiRangeToXPointers(
+                    annotation.cfi
+                )
+
+                local koreader_annotation = {
+                    grimmory_id = annotation.id,
+
+                    datetime = to_annotation_datetime(annotation.created_at),
+                    datetime_updated = to_annotation_datetime(annotation.updated_at),
+
+                    color = GRIMMORY_COLOR_MAP[annotation.color] or DEFAULT_KOREADER_COLOR,
+                    drawer = GRIMMORY_STYLE_MAP[annotation.style] or DEFAULT_KOREADER_STYLE,
+
+                    chapter = annotation.chapter,
+                    text = annotation.text,
+
+                    page = xpointer_start,
+
+                    pos0 = xpointer_start,
+                    pos1 = xpointer_end,
+                }
+
+                table.insert(remote_annotations, koreader_annotation)
+            end
+        end
+    )
+
+    local local_annotations = self.doc_metadata:getAnnotations(book_path)
+
+    local new_annotations = merge_annotations(local_annotations, remote_annotations)
+
+    self.doc_metadata:setAnnotations(book_path, new_annotations)
+end
+
+---@return GrimmoryAnnotation[] annotations
+function GrimmoryReadingAnnotations:getAnnotations(book_path)
+    -- Get annotations for book
+    local annotations = self.doc_metadata:getAnnotations(book_path)
+
+    local grimmory_annotations = {}
+
+    with_cfi_resolver(
+        book_path,
+        function(cfi_resolver)
+            for _, annotation in ipairs(annotations) do
+                ---@type GrimmoryAnnotation
+                local grimmory_annotation = {
+                    id = annotation.grimmory_id,
+                    book_id = -1,
+                    created_at = from_annotation_datetime(annotation.datetime),
+                    updated_at = from_annotation_datetime(annotation.datetime_updated),
+                    cfi = cfi_resolver:xpointerRangeToCFI(annotation.pos0, annotation.pos1),
+                    chapter = annotation.chapter,
+                    text = annotation.text,
+                    color = KOREADER_COLOR_MAP[annotation.color] or DEFAULT_GRIMMORY_COLOR,
+                    style = KOREADER_STYLE_MAP[annotation.drawer] or DEFAULT_GRIMMORY_STYLE,
+                }
+
+                table.insert(grimmory_annotations, grimmory_annotation)
+            end
+        end
+    )
+
+    return grimmory_annotations
+end
+
+return GrimmoryReadingAnnotations

--- a/grimmory.koplugin/grimmory/reading/annotations.lua
+++ b/grimmory.koplugin/grimmory/reading/annotations.lua
@@ -190,6 +190,7 @@ local function merge_annotations(local_annotations, remote_annotations)
                     existing_annotation.chapter = annotation.chapter
                     existing_annotation.text = annotation.text
                     existing_annotation.page = annotation.page
+                    existing_annotation.note = annotation.note
                 end
             end
 
@@ -210,6 +211,7 @@ local function merge_annotations(local_annotations, remote_annotations)
             existing_annotation.chapter = annotation.chapter
             existing_annotation.text = annotation.text
             existing_annotation.page = annotation.page
+            existing_annotation.note = annotation.note
         end
     end
 
@@ -245,6 +247,7 @@ function GrimmoryReadingAnnotations:applyAnnotations(book_path, grimmory_annotat
 
                     chapter = annotation.chapter,
                     text = annotation.text,
+                    note = annotation.note,
 
                     page = xpointer_start,
 

--- a/grimmory.koplugin/grimmory/settings.lua
+++ b/grimmory.koplugin/grimmory/settings.lua
@@ -36,6 +36,7 @@ local logger = GrimmoryLogger:new()
 ---@field sync_download_directory string
 ---@field sync_reading_sessions boolean
 ---@field sync_reading_progress boolean
+---@field sync_annotations boolean
 ---@field sync_shelves_as_collections boolean
 ---@field sync_retain_empty_shelves boolean
 ---@field device_id string
@@ -62,6 +63,7 @@ local DEFAULTS = {
     sync_download_directory = "grimmory/",
     sync_reading_sessions = true,
     sync_reading_progress = true,
+    sync_annotations = true,
     sync_shelves_as_collections = true,
     sync_retain_empty_shelves = false,
     device_id = random.uuid(),
@@ -271,6 +273,19 @@ end
 
 function GrimmorySettings:toggleSyncReadingSessions()
     self.data.sync_reading_sessions = not self:getSyncReadingSessions()
+    self:write()
+end
+
+function GrimmorySettings:getSyncAnnotations()
+    if self.data.sync_annotations == nil then
+        return DEFAULTS.sync_annotations
+    end
+
+    return self.data.sync_annotations
+end
+
+function GrimmorySettings:toggleSyncAnnotations()
+    self.data.sync_annotations = not self:getSyncAnnotations()
     self:write()
 end
 

--- a/grimmory.koplugin/grimmory/synchronize.lua
+++ b/grimmory.koplugin/grimmory/synchronize.lua
@@ -8,6 +8,7 @@ local logger = GrimmoryLogger:new()
 
 ---@class GrimmorySynchronize
 ---@field repository GrimmoryLocalRepository
+---@field reading_annotations GrimmoryReadingAnnotations
 ---@field reading_progress_manager ReadingProgressManager
 ---@field settings GrimmorySettings
 ---@field api GrimmoryAPI
@@ -160,6 +161,71 @@ function GrimmorySynchronize:pushBookSessions(book_id, callback)
             end
         end
     end
+end
+
+---@param book_path string
+---@param book_grimmory_id integer
+function GrimmorySynchronize:pushBookAnnotations(book_path, book_grimmory_id)
+    local local_annotations = self.reading_annotations:getAnnotations(book_path)
+
+    local modified_grimmory_annotations = self.doc_metadata:getModifiedGrimmoryAnnotations(book_path)
+
+    local is_modified_by_id = {}
+    for _, modified_id in ipairs(modified_grimmory_annotations) do
+        is_modified_by_id[tostring(modified_id)] = true
+
+        logger:dbg("Deleting annotation frim Grimmory:", book_path, "-", modified_id)
+        self.api:deleteAnnotation(modified_id)
+
+        -- Even if the delete fails - which it does today with a 5xx instead of 404 - we
+        -- should continue to remove the annotation and assume it's just gone.
+        --
+        -- Once this bug (grimmory-tools/grimmory#1858) is fixed we can add the check
+        -- back in for the `ok` of `deleteAnnotation` calls.
+        self.doc_metadata:removeModifiedGrimmoryAnnotation(book_path, modified_id)
+    end
+
+    for _, annotation in ipairs(local_annotations) do
+        if annotation.id ~= nil and is_modified_by_id[tostring(annotation.id)] then
+            annotation.id = nil
+        end
+
+        if annotation.id == nil then
+            -- This is a "new" annotation.
+            local create_ok, remote_annotation = self.api:createAnnotation(
+                book_grimmory_id,
+                annotation.cfi,
+                annotation.chapter,
+                annotation.text,
+                annotation.color,
+                annotation.style
+            )
+
+            if create_ok then
+                logger:dbg("Created annotation for book:", book_path)
+            else
+                logger:err("Failed to push annotation", remote_annotation)
+            end
+        end
+    end
+end
+
+---@param book_path string
+---@param book_grimmory_id integer
+function GrimmorySynchronize:pullBookAnnotations(book_path, book_grimmory_id)
+    local annotations_ok, annotations = self.api:getAnnotations(book_grimmory_id)
+
+    if not annotations_ok or annotations == nil then
+        logger:err("Failed pulling annotations from Grimmory:", book_grimmory_id)
+        return
+    end
+
+    logger:dbg("Writing annotations to:", book_path)
+
+    self.reading_annotations:applyAnnotations(
+        book_path,
+        annotations
+    )
 end
 
 ---@param book_id integer
@@ -874,6 +940,15 @@ function GrimmorySynchronize:synchronizeBook(book_path, refresh_book, callback)
         else
             logger:warn("Unable to locate book in Grimmory:", book_path)
         end
+    end
+
+    -- Pull annotations from Grimmory
+    if grimmory_id then
+        logger:info("Pushing book annotations:", book_path)
+        self:pushBookAnnotations(book_path, grimmory_id)
+
+        logger:info("Pulling book annotations:", book_path)
+        self:pullBookAnnotations(book_path, grimmory_id)
     end
 
     -- First, tell Grimmory about all of our reading

--- a/grimmory.koplugin/grimmory/synchronize.lua
+++ b/grimmory.koplugin/grimmory/synchronize.lua
@@ -198,7 +198,8 @@ function GrimmorySynchronize:pushBookAnnotations(book_path, book_grimmory_id)
                 annotation.chapter,
                 annotation.text,
                 annotation.color,
-                annotation.style
+                annotation.style,
+                annotation.note
             )
 
             if create_ok then

--- a/grimmory.koplugin/grimmory/ui/menu.lua
+++ b/grimmory.koplugin/grimmory/ui/menu.lua
@@ -162,6 +162,17 @@ function GrimmoryMenu:getSyncOptionsMenu()
             separator = true,
         },
         {
+            text = _("Sync Annotations"),
+            checked_func = function()
+                return self.settings:getSyncAnnotations()
+            end,
+            callback = function()
+                self.settings:toggleSyncAnnotations()
+                UIManager:broadcastEvent(Event:new("GrimmorySettingsChanged"))
+            end,
+            separator = true,
+        },
+        {
             text = _("Sync Reading Progress"),
             checked_func = function()
                 return self.settings:getSyncReadingProgress()

--- a/grimmory.koplugin/main.lua
+++ b/grimmory.koplugin/main.lua
@@ -27,6 +27,7 @@ local GithubAPI = require("grimmory/ota/github_api")
 local GrimmoryLogger = require("grimmory/logger")
 local GrimmoryReadingRecorder = require("grimmory/reading/recorder")
 local GrimmoryLocalRepository = require("grimmory/repository")
+local GrimmoryReadingAnnotations = require("grimmory/reading/annotations")
 local GrimmoryReadingProgressManager = require("grimmory/reading/progress_manager")
 
 
@@ -105,6 +106,8 @@ function Grimmory:init()
         settings = self.settings
     })
 
+    self.reading_annotations = GrimmoryReadingAnnotations:new(self.doc_metadata)
+
     self.reading_progress_manager = GrimmoryReadingProgressManager:new({
         ui = self.ui,
         api = self.api,
@@ -132,6 +135,7 @@ function Grimmory:init()
         api = self.api,
         doc_metadata = self.doc_metadata,
         reading_progress_manager = self.reading_progress_manager,
+        reading_annotations = self.reading_annotations,
     })
 
     self.executor = GrimmoryExecutor:new()
@@ -256,14 +260,26 @@ end
 function Grimmory:onAnnotationsModified(annotation_info)
     logger:dbg("Annotations modified", annotation_info)
 
-    -- annotation is at annotation_info[1]
+    local annotation = annotation_info[1]
 
+    local is_modified = false
     if annotation_info.index_modified == nil then
         self.reading_recorder:onAnnotationUpdated()
+        is_modified = true
     elseif annotation_info.index_modified < 0 then
         self.reading_recorder:onAnnotationRemoved()
+        is_modified = true
     else
         self.reading_recorder:onAnnotationAdded()
+    end
+
+    if is_modified and self.ui ~= nil and self.ui.document ~= nil and self.ui.document.file ~= nil then
+        if annotation.grimmory_id ~= nil then
+            self.doc_metadata:appendModifiedGrimmoryAnnotation(
+                self.ui.document.file,
+                annotation.grimmory_id
+            )
+        end
     end
 end
 

--- a/spec/grimmory/reading/annotations_spec.lua
+++ b/spec/grimmory/reading/annotations_spec.lua
@@ -1,0 +1,153 @@
+local assert = require 'luassert'
+local match = require 'luassert.match'
+local spy = require 'luassert.spy'
+local stub = require 'luassert.stub'
+
+package.path = "grimmory.koplugin/?.lua;" .. package.path
+
+
+local fake_document = stub.new()
+local mock_has_provider = spy.new(function() return true end)
+local mock_open_document = spy.new(function() return fake_document end)
+
+package.preload["document/documentregistry"] = function()
+    return {
+        hasProvider = mock_has_provider,
+        openDocument = mock_open_document,
+    }
+end
+
+local fake_cfi_resolver = stub.new()
+local mock_cfi_resolver_new = spy.new(function() return fake_cfi_resolver end)
+
+package.preload["grimmory/cfi_resolver"] = function()
+    return {
+        new = mock_cfi_resolver_new,
+    }
+end
+
+local fake_doc_metadata = stub.new()
+
+local GrimmoryReadingAnnotations = require("grimmory/reading/annotations")
+
+
+local remote_grimmory_annotation = {
+    ["id"] = 27,
+    ["chapter"] = "Logical Reading Order",
+    ["color"] = "",
+    ["created_at"] = 1781321340,
+    ["style"] = "highlight",
+    ["page"] = "start",
+    ["pos0"] = "start",
+    ["pos1"] = "end",
+    ["text"] = "Although you’ll hear that all EPUB 3s have a default reading order",
+}
+
+local local_grimmory_annotation = {
+    ["chapter"] = "Logical Reading Order",
+    ["color"] = "yellow",
+    ["datetime"] = "2026-06-13 03:29:00Z",
+    ["drawer"] = "lighten",
+    ["grimmory_id"] = 27,
+    ["page"] = "start",
+    ["pos0"] = "start",
+    ["pos1"] = "end",
+    ["text"] = "Although you’ll hear that all EPUB 3s have a default reading order",
+}
+
+local local_annotation = {
+    ["chapter"] = "Lists",
+    ["color"] = "yellow",
+    ["datetime"] = "2026-06-13 03:20:33Z",
+    ["drawer"] = "lighten",
+    ["page"] = "/body/DocFragment[12]/body/section/section/section[8]/p[3]/text()",
+    ["pageno"] = 44,
+    ["pos0"] = "/body/DocFragment[12]/body/section/section/section[8]/p[3]/text()",
+    ["pos1"] = "/body/DocFragment[12]/body/section/section/section[8]/p[3]/text().163",
+    ["text"] = "element, on the other hand, provides the ability both to move quickly " ..
+                "from item to item and to escape the list entirely. It also allows a " ..
+                "reading system to",
+}
+
+
+describe("GrimmoryReadingAnnotations", function()
+    before_each(function()
+        fake_document.loadDocument = spy.new(function() return true end)
+        fake_document.close = spy.new(function() end)
+
+        fake_cfi_resolver.cfiRangeToXPointers = spy.new(function() return "start", "end" end)
+        fake_cfi_resolver.xpointerRangeToCFI = spy.new(function() return "cfi" end)
+
+        stub(fake_doc_metadata, "getAnnotations").returns({})
+        stub(fake_doc_metadata, "setAnnotations")
+    end)
+
+    describe("mergeAnnotations", function()
+        it("removes missing grimmory annotations", function()
+            local expected = {}
+
+            fake_doc_metadata.getAnnotations.returns({
+                local_grimmory_annotation,
+            })
+
+            local annotations = GrimmoryReadingAnnotations:new(fake_doc_metadata)
+
+            annotations:applyAnnotations("book_path", {})
+
+            assert.spy(fake_doc_metadata.setAnnotations).was_called_with(
+                match._,
+                match.same("book_path"),
+                match.same(expected)
+            )
+        end)
+
+        it("retains non-grimmory annotations", function()
+            local expected = { local_annotation }
+            fake_doc_metadata.getAnnotations.returns({ local_annotation })
+
+            local annotations = GrimmoryReadingAnnotations:new(fake_doc_metadata)
+
+            annotations:applyAnnotations("book_path", {})
+
+            assert.spy(fake_doc_metadata.setAnnotations).was_called_with(
+                match._,
+                match.same("book_path"),
+                match.same(expected)
+            )
+        end)
+
+        it("appends grimmory annotations", function()
+            local expected = {
+                local_annotation,
+                local_grimmory_annotation,
+            }
+            fake_doc_metadata.getAnnotations.returns({ local_annotation })
+
+            local annotations = GrimmoryReadingAnnotations:new(fake_doc_metadata)
+
+            annotations:applyAnnotations("book_path", {
+                remote_grimmory_annotation
+            })
+
+            assert.spy(fake_doc_metadata.setAnnotations).was_called_with(
+                fake_doc_metadata,
+                "book_path",
+                expected
+            )
+        end)
+    end)
+
+    describe("getAnnotations", function()
+        it("translates colors and styles for local annotations", function()
+            fake_doc_metadata.getAnnotations.returns({ local_annotation })
+
+            local annotations = GrimmoryReadingAnnotations:new(fake_doc_metadata)
+
+            local actual = annotations:getAnnotations("book_path")
+
+            assert.equal(1, #actual)
+            assert.equal("#FFC107", actual[1].color)
+            assert.equal("highlight", actual[1].style)
+        end)
+    end)
+end)


### PR DESCRIPTION
adds synchronization of highlights and notes with Grimmory on open books

fixes #65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-book annotation sync with Grimmory (push local highlights/notes, pull remote updates) with correct position mapping and styling.
  * Added a new setting to enable/disable annotation syncing.
  * Improved edit tracking so modified annotations are updated cleanly during the next sync cycle.
* **Bug Fixes**
  * Improved merging to match and update existing annotations while retaining locally stored non-Grimmory items, reducing duplicates.
  * More resilient handling when remote annotations are missing or removal/update operations fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->