### PR TITLE
feat: add option to delete books on sync

### DIFF
--- a/grimmory.koplugin/grimmory/doc_metadata.lua
+++ b/grimmory.koplugin/grimmory/doc_metadata.lua
@@ -22,6 +22,14 @@ function DocMetadata:init()
     self.props_cache = Cache:new({ slots = 1024 })
 end
 
+function DocMetadata:purge(path)
+    local settings = self:getDocSettings(path)
+
+    if settings ~= nil then
+        settings:purge()
+    end
+end
+
 function DocMetadata:getDocSettings(path)
     local settings = DocSettings:open(path)
 

--- a/grimmory.koplugin/grimmory/repository.lua
+++ b/grimmory.koplugin/grimmory/repository.lua
@@ -209,6 +209,53 @@ function GrimmoryLocalRepository:upsertBook(book_path, grimmory_id)
     return true, book_id
 end
 
+---@param book_path string
+---@param partial_md5 string
+---@return boolean ok
+---@return integer | nil book_id
+---@return integer | nil grimmory_id
+function GrimmoryLocalRepository:findBookByFile(book_path, partial_md5)
+    local ok, book = self:withDatabase(
+        function(conn)
+            local select_stmt = conn:prepare([[
+                SELECT
+                    id,
+                    grimmory_id
+                FROM book
+                WHERE
+                    book_path = ?
+                    AND
+                    partial_md5 = ?
+            ]])
+
+            select_stmt:bind(book_path, partial_md5)
+            local row = select_stmt:step()
+            select_stmt:close()
+
+            if not row then
+                return nil
+            end
+
+            return {
+                id = tonumber(row[1]),
+                grimmory_id = tonumber(row[2]),
+            }
+        end
+    )
+
+    if not ok then
+        logger:err("Failed to find book:", book_path, partial_md5, "-", book)
+        return false, nil, nil
+    end
+
+    if not book then
+        logger:dbg("Book query succees but did not find book:", book_path, partial_md5)
+        return true, nil, nil
+    end
+
+    return true, book.id, book.grimmory_id
+end
+
 ---@param grimmory_id number
 ---@return boolean ok
 ---@return string | nil book_path

--- a/grimmory.koplugin/grimmory/settings.lua
+++ b/grimmory.koplugin/grimmory/settings.lua
@@ -30,6 +30,7 @@ local logger = GrimmoryLogger:new()
 ---@field sync_periodically boolean
 ---@field sync_frequency number
 ---@field sync_shelves boolean
+---@field download_remove_books boolean
 ---@field sync_target_shelves GrimmoryTargetShelf[]
 ---@field sync_download_directory string
 ---@field sync_reading_sessions boolean
@@ -52,6 +53,7 @@ local DEFAULTS = {
     sync_periodically = false,
     sync_frequency = 120,
     sync_shelves = true,
+    download_remove_books = false,
     sync_target_shelves = {},
     sync_download_directory = "grimmory/",
     sync_reading_sessions = true,
@@ -195,6 +197,19 @@ end
 
 function GrimmorySettings:toggleDownloadsBooks()
     self.data.sync_shelves = not self:getDownloadsBooks()
+    self:write()
+end
+
+function GrimmorySettings:getDownloadRemoveBooks()
+    if self.data.download_remove_books == nil then
+        return DEFAULTS.download_remove_books
+    end
+
+    return self.data.download_remove_books
+end
+
+function GrimmorySettings:toggleDownloadRemoveBooks()
+    self.data.download_remove_books = not self:getDownloadRemoveBooks()
     self:write()
 end
 

--- a/grimmory.koplugin/grimmory/synchronize.lua
+++ b/grimmory.koplugin/grimmory/synchronize.lua
@@ -370,8 +370,9 @@ function GrimmorySynchronize:downloadBook(book_id, download_path)
 end
 
 ---@param book Book
----@return string | nil download_path
-function GrimmorySynchronize:getBookDownloadPath(book)
+---@param filename string
+---@return string download_path
+function GrimmorySynchronize:getBookDownloadPath(book, filename)
     local existing_book_ok, existing_book_path = self.repository:findBookByGrimmoryId(book.id)
     if existing_book_ok and existing_book_path then
         return existing_book_path
@@ -383,7 +384,7 @@ function GrimmorySynchronize:getBookDownloadPath(book)
         error("Download directory is invalid")
     end
 
-    local download_path = download_directory .. "/" .. util.getSafeFilename(book.primary_file.filename)
+    local download_path = download_directory .. "/" .. util.getSafeFilename(filename)
 
     -- If this path doesn't exist yet, we're good, bail early
     if not util.fileExists(download_path) then
@@ -399,7 +400,7 @@ function GrimmorySynchronize:getBookDownloadPath(book)
     -- At this point we need a fallback name.  `downloaded-${BOOK_ID}.${EXT}` is not
     -- great but I don't know a better safe way off hand.
 
-    local file_extension = util.getFileNameSuffix(book.primary_file.filename)
+    local file_extension = util.getFileNameSuffix(filename)
 
     if file_extension == "" or file_extension == nil then
         file_extension = "bin"
@@ -463,21 +464,12 @@ end
 
 
 ---@param book Book
----@param callback function
-function GrimmorySynchronize:pullBook(book, callback)
+---@param filename string
+---@return string download_path
+function GrimmorySynchronize:pullBook(book, filename)
     local book_exists = false
 
-    if book.primary_file == nil then
-        logger:dbg("Skipping book without file:", book.id)
-        callback({
-            state = "book-skipped",
-            book_id = book.id,
-            download_path = nil,
-        })
-        return
-    end
-
-    local download_path = self:getBookDownloadPath(book)
+    local download_path = self:getBookDownloadPath(book, filename)
 
     -- TODO: Search through known books from collections for this book
     --       If found, set the `download path to that value.
@@ -512,6 +504,25 @@ function GrimmorySynchronize:pullBook(book, callback)
     return download_path
 end
 
+---@param book_path string
+function GrimmorySynchronize:removeBook(book_path)
+    logger:info("Removing book at:", book_path)
+
+    -- Remove book file
+    local ok = util.removeFile(book_path)
+
+    if not ok then
+        logger:err("Failed to remove file at:", book_path)
+        return
+    end
+
+    -- Remove from all collections (skip writes)
+    ReadCollection:removeItem(book_path, nil, true)
+
+    -- Remove sidecar
+    self.doc_metadata:purge(book_path)
+end
+
 function GrimmorySynchronize:pullBooks(callback)
     if not self.settings:getDownloadsBooks() then
         logger:info("Book download skipped because feature is disabled")
@@ -532,10 +543,17 @@ function GrimmorySynchronize:pullBooks(callback)
         return
     end
 
+    local seen_books = {}
+    local seen_grimmory_ids = {}
+
     for book, element_count, total_books in self.api:getBooks() do
         if self:isTargetBook(book) then
+            seen_grimmory_ids[tostring(book.id)] = true
+
             local pull_ok, pull_path_or_message = pcall(self.pullBook, self, book, callback)
             if pull_ok then
+                seen_books[pull_path_or_message] = true
+
                 callback({
                     state = "book-downloaded",
                     book_id = book.id,
@@ -554,6 +572,45 @@ function GrimmorySynchronize:pullBooks(callback)
                 })
             end
         end
+    end
+
+    if self.settings:getDownloadRemoveBooks() then
+        logger:dbg("Checking if any books need to be removed")
+
+        -- Iterate through books in download directory and
+        -- remove when not in the `seen_books` set
+        util.findFiles(
+            download_directory,
+            function(path)
+                if path:match("%.sdr/") then
+                    -- Ignore sidecar directory
+                    return
+                end
+
+                if seen_books[path] then
+                    -- We saw this specific file and can skip
+                    -- We don't need to do the database lookup
+                    return
+                end
+
+                local partial_md5 = util.partialMD5(path)
+                local found_ok, _, grimmory_id = self.repository:findBookByFile(path, partial_md5)
+
+                if not found_ok or not grimmory_id then
+                    -- Skip file, not tracked in database for some reason
+                    logger:dbg("Skipping file removal, not in database:", path, partial_md5)
+                    return
+                end
+
+                if seen_grimmory_ids[tostring(grimmory_id)] then
+                    -- We saw this Grimmory ID as a valid book to keep on-device.
+                    return
+                end
+
+                self:removeBook(path)
+            end,
+            true
+        )
     end
 
     -- During pulling books we may have updated the collections that

--- a/grimmory.koplugin/grimmory/synchronize.lua
+++ b/grimmory.koplugin/grimmory/synchronize.lua
@@ -370,9 +370,8 @@ function GrimmorySynchronize:downloadBook(book_id, download_path)
 end
 
 ---@param book Book
----@param filename string
 ---@return string download_path
-function GrimmorySynchronize:getBookDownloadPath(book, filename)
+function GrimmorySynchronize:getBookDownloadPath(book)
     local existing_book_ok, existing_book_path = self.repository:findBookByGrimmoryId(book.id)
     if existing_book_ok and existing_book_path then
         return existing_book_path
@@ -384,29 +383,35 @@ function GrimmorySynchronize:getBookDownloadPath(book, filename)
         error("Download directory is invalid")
     end
 
-    local download_path = download_directory .. "/" .. util.getSafeFilename(filename)
+    if book.primary_file then
+        local download_path = download_directory .. "/" .. util.getSafeFilename(book.primary_file.filename)
 
-    -- If this path doesn't exist yet, we're good, bail early
-    if not util.fileExists(download_path) then
-        return download_path
-    end
+        -- If this path doesn't exist yet, we're good, bail early
+        if not util.fileExists(download_path) then
+            return download_path
+        end
 
-    -- If the path exists we have to check to make sure that it is actually the book we care about
-    if self.doc_metadata:isBook(download_path, book) then
-        -- We have a match, this path is safe.
-        return download_path
+        -- If the path exists we have to check to make sure that it is actually the book we care about
+        if self.doc_metadata:isBook(download_path, book) then
+            -- We have a match, this path is safe.
+            return download_path
+        end
     end
 
     -- At this point we need a fallback name.  `downloaded-${BOOK_ID}.${EXT}` is not
     -- great but I don't know a better safe way off hand.
 
-    local file_extension = util.getFileNameSuffix(filename)
+    local file_extension = nil
+
+    if book.primary_file ~= nil then
+        file_extension = util.getFileNameSuffix(book.primary_file.filename)
+    end
 
     if file_extension == "" or file_extension == nil then
         file_extension = "bin"
     end
 
-    download_path = download_directory .. "/downloaded-" .. tonumber(book.id) .. "." .. file_extension
+    local download_path = download_directory .. "/downloaded-" .. tonumber(book.id) .. "." .. file_extension
 
     -- If this path doesn't exist yet, we're good?
     if not util.fileExists(download_path) then
@@ -464,12 +469,11 @@ end
 
 
 ---@param book Book
----@param filename string
 ---@return string download_path
-function GrimmorySynchronize:pullBook(book, filename)
+function GrimmorySynchronize:pullBook(book)
     local book_exists = false
 
-    local download_path = self:getBookDownloadPath(book, filename)
+    local download_path = self:getBookDownloadPath(book)
 
     -- TODO: Search through known books from collections for this book
     --       If found, set the `download path to that value.

--- a/grimmory.koplugin/grimmory/ui/menu.lua
+++ b/grimmory.koplugin/grimmory/ui/menu.lua
@@ -214,7 +214,7 @@ function GrimmoryMenu:getDownloadOptionsMenu()
             separator = true,
         },
         {
-            text = _("Remove Books when Remote Missing"),
+            text = _("Permanently Delete Removed Books"),
             checked_func = function()
                 return self.settings:getDownloadRemoveBooks()
             end,

--- a/grimmory.koplugin/grimmory/ui/menu.lua
+++ b/grimmory.koplugin/grimmory/ui/menu.lua
@@ -213,6 +213,16 @@ function GrimmoryMenu:getDownloadOptionsMenu()
             end,
             separator = true,
         },
+        {
+            text = _("Remove Books when Remote Missing"),
+            checked_func = function()
+                return self.settings:getDownloadRemoveBooks()
+            end,
+            callback = function()
+                self.settings:toggleDownloadRemoveBooks()
+                UIManager:broadcastEvent(Event:new("GrimmorySettingsChanged"))
+            end,
+        }
     }
 end
 


### PR DESCRIPTION
adds an option to the sync configuration which will permanently delete books which no longer exist in Grimmory based on our download matching criteria.  this includes books deleted from Grimmory, books that are no longer on a targeted shelf, or books that a user no longer has permission to see

this permanently deletes the book from the device including all sidecar data

this feature is OFF by default

fixes #78

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Permanently Delete Removed Books" toggle in Download Options to auto-remove library-removed files from the download folder.
  * Downloads now pick safer filenames and more reliably determine when a book needs to be fetched.

* **Bug Fixes / Improvements**
  * Optional cleanup pass removes orphaned download files while preserving in-use items.
  * Improved handling and cleanup of document metadata when files are removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->