### PR TITLE
chore: rename download settings and move download config menu

### DIFF
--- a/grimmory.koplugin/grimmory/settings.lua
+++ b/grimmory.koplugin/grimmory/settings.lua
@@ -185,7 +185,7 @@ function GrimmorySettings:setSessionThresholdPages(pages)
     self:write()
 end
 
-function GrimmorySettings:getSyncShelves()
+function GrimmorySettings:getDownloadsBooks()
     if self.data.sync_shelves == nil then
         return DEFAULTS.sync_shelves
     end
@@ -193,27 +193,27 @@ function GrimmorySettings:getSyncShelves()
     return self.data.sync_shelves
 end
 
-function GrimmorySettings:toggleSyncShelves()
-    self.data.sync_shelves = not self:getSyncShelves()
+function GrimmorySettings:toggleDownloadsBooks()
+    self.data.sync_shelves = not self:getDownloadsBooks()
     self:write()
 end
 
-function GrimmorySettings:getSyncDownloadDirectory()
+function GrimmorySettings:getDownloadDirectory()
     return self.data.sync_download_directory or DEFAULTS.sync_download_directory
 end
 
 ---@param directory string
-function GrimmorySettings:setSyncDownloadDirectory(directory)
+function GrimmorySettings:setDownloadDirectory(directory)
     self.data.sync_download_directory = directory
     self:write()
 end
 
-function GrimmorySettings:getSyncTargetShelves()
+function GrimmorySettings:getDownloadTargetShelves()
     return self.data.sync_target_shelves or DEFAULTS.sync_target_shelves
 end
 
 ---@param target_shelves GrimmoryTargetShelf[]
-function GrimmorySettings:setSyncTargetShelves(target_shelves)
+function GrimmorySettings:setDownloadTargetShelves(target_shelves)
     self.data.sync_target_shelves = target_shelves
     self:write()
 end

--- a/grimmory.koplugin/grimmory/synchronize.lua
+++ b/grimmory.koplugin/grimmory/synchronize.lua
@@ -175,7 +175,7 @@ function GrimmorySynchronize:isTargetBook(book)
         return false
     end
 
-    local target_shelves = self.settings:getSyncTargetShelves() or {}
+    local target_shelves = self.settings:getDownloadTargetShelves() or {}
 
     if #target_shelves == 0 then
         return true
@@ -195,7 +195,7 @@ function GrimmorySynchronize:isTargetBook(book)
 end
 
 function GrimmorySynchronize:isTargetShelf(shelf_id)
-    local target_shelves = self.settings:getSyncTargetShelves() or {}
+    local target_shelves = self.settings:getDownloadTargetShelves() or {}
 
     if #target_shelves == 0 then
         return true
@@ -211,7 +211,7 @@ function GrimmorySynchronize:isTargetShelf(shelf_id)
 end
 
 function GrimmorySynchronize:synchronizeShelves(callback)
-    if not self.settings:getSyncShelves() then
+    if not self.settings:getDownloadsBooks() then
         logger:info("Shelf sync skipped because feature is disabled")
         return
     end
@@ -377,7 +377,7 @@ function GrimmorySynchronize:getBookDownloadPath(book)
         return existing_book_path
     end
 
-    local download_directory = self.settings:getSyncDownloadDirectory()
+    local download_directory = self.settings:getDownloadDirectory()
 
     if not download_directory or download_directory == "" then
         error("Download directory is invalid")
@@ -513,12 +513,12 @@ function GrimmorySynchronize:pullBook(book, callback)
 end
 
 function GrimmorySynchronize:pullBooks(callback)
-    if not self.settings:getSyncShelves() then
+    if not self.settings:getDownloadsBooks() then
         logger:info("Book download skipped because feature is disabled")
         return
     end
 
-    local download_directory = self.settings:getSyncDownloadDirectory()
+    local download_directory = self.settings:getDownloadDirectory()
     if not download_directory or download_directory == "" then
         logger:err("Book download skipped because download directory is not set")
         return

--- a/grimmory.koplugin/grimmory/ui/dialog_manager.lua
+++ b/grimmory.koplugin/grimmory/ui/dialog_manager.lua
@@ -143,7 +143,7 @@ function DialogManager:showTargetShelvesSettings()
                 text = _("All Shelves"),
                 callback = function()
                     logger:dbg("Set target shelves to All Shelves")
-                    self.settings:setSyncTargetShelves({})
+                    self.settings:setDownloadTargetShelves({})
 
                     UIManager:broadcastEvent(Event:new("GrimmorySettingsChanged"))
 
@@ -173,7 +173,7 @@ function DialogManager:showTargetShelvesSettings()
                     text = uniqueShelfName,
                     callback = function()
                         logger:dbg("Set target shelves to shelf ID", shelfId)
-                        self.settings:setSyncTargetShelves({ { id = shelfId, name = uniqueShelfName } })
+                        self.settings:setDownloadTargetShelves({ { id = shelfId, name = uniqueShelfName } })
 
                         UIManager:broadcastEvent(Event:new("GrimmorySettingsChanged"))
 
@@ -283,9 +283,9 @@ function DialogManager:showDownloadDirectorySettings()
         title = "Download Directory",
         select_file = false,
         show_files = false,
-        path = self.settings:getSyncDownloadDirectory(),
+        path = self.settings:getDownloadDirectory(),
         onConfirm = function(newPath)
-            self.settings:setSyncDownloadDirectory(newPath)
+            self.settings:setDownloadDirectory(newPath)
         end,
     })
 

--- a/grimmory.koplugin/grimmory/ui/menu.lua
+++ b/grimmory.koplugin/grimmory/ui/menu.lua
@@ -174,33 +174,8 @@ function GrimmoryMenu:getSyncOptionsMenu()
     }
 end
 
-function GrimmoryMenu:getTopMenu()
-    local menu = {
-        {
-            text = _("Connection Settings"),
-            callback = function()
-                self.dialog_manager:showConnectionSettings()
-            end,
-        },
-        {
-            text = _("Automatic Sync"),
-            sub_item_table = self:getAutomaticSyncOptionsMenu()
-        },
-        {
-            text = _("Sync Configuration"),
-            sub_item_table = self:getSyncOptionsMenu(),
-            separator = true,
-        },
-        {
-            text = _("Download Books"),
-            checked_func = function()
-                return self.settings:getSyncShelves()
-            end,
-            callback = function()
-                self.settings:toggleSyncShelves()
-                UIManager:broadcastEvent(Event:new("GrimmorySettingsChanged"))
-            end,
-        },
+function GrimmoryMenu:getDownloadOptionsMenu()
+    return {
         {
             text = _("Set Download Directory"),
             callback = function()
@@ -211,7 +186,7 @@ function GrimmoryMenu:getTopMenu()
             text_func = function()
                 local targetDescription = "All"
 
-                local targetShelves = self.settings:getSyncTargetShelves()
+                local targetShelves = self.settings:getDownloadTargetShelves()
 
                 local count = 0
                 for _, shelf in ipairs(targetShelves) do
@@ -236,6 +211,41 @@ function GrimmoryMenu:getTopMenu()
             callback = function()
                 self.dialog_manager:showTargetShelvesSettings()
             end,
+            separator = true,
+        },
+    }
+end
+
+function GrimmoryMenu:getTopMenu()
+    local menu = {
+        {
+            text = _("Connection Settings"),
+            callback = function()
+                self.dialog_manager:showConnectionSettings()
+            end,
+        },
+        {
+            text = _("Automatic Sync"),
+            sub_item_table = self:getAutomaticSyncOptionsMenu()
+        },
+        {
+            text = _("Sync Configuration"),
+            sub_item_table = self:getSyncOptionsMenu(),
+            separator = true,
+        },
+        {
+            text = _("Download Books"),
+            checked_func = function()
+                return self.settings:getDownloadsBooks()
+            end,
+            callback = function()
+                self.settings:toggleDownloadsBooks()
+                UIManager:broadcastEvent(Event:new("GrimmorySettingsChanged"))
+            end,
+        },
+        {
+            text = _("Download Configuration"),
+            sub_item_table = self:getDownloadOptionsMenu(),
             separator = true,
         },
         {


### PR DESCRIPTION
makes it clearer what the download settings are for (download of books, not sync)

related to #124 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated "Download Configuration" submenu for managing download directory and target shelf selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->