### PR TITLE
feat: add support for syncing all shelves separate from download

### DIFF
--- a/grimmory.koplugin/grimmory/settings.lua
+++ b/grimmory.koplugin/grimmory/settings.lua
@@ -35,7 +35,7 @@ local logger = GrimmoryLogger:new()
 ---@field sync_reading_sessions boolean
 ---@field sync_reading_progress boolean
 ---@field sync_shelves_as_collections boolean
----@field sync_empty_shelves boolean
+---@field sync_retain_empty_shelves boolean
 ---@field device_id string
 ---@field device_name string
 
@@ -59,7 +59,7 @@ local DEFAULTS = {
     sync_reading_sessions = true,
     sync_reading_progress = true,
     sync_shelves_as_collections = true,
-    sync_empty_shelves = false,
+    sync_retain_empty_shelves = false,
     device_id = random.uuid(),
     device_name = Device.model,
 }
@@ -261,16 +261,16 @@ function GrimmorySettings:toggleSyncShelves()
     self:write()
 end
 
-function GrimmorySettings:getSyncEmptyShelves()
-    if self.data.sync_empty_shelves == nil then
-        return DEFAULTS.sync_empty_shelves
+function GrimmorySettings:getSyncRetainEmptyShelves()
+    if self.data.sync_retain_empty_shelves == nil then
+        return DEFAULTS.sync_retain_empty_shelves
     end
 
-    return self.data.sync_empty_shelves
+    return self.data.sync_retain_empty_shelves
 end
 
-function GrimmorySettings:toggleSyncEmptyShelves()
-    self.data.sync_empty_shelves = not self:getSyncEmptyShelves()
+function GrimmorySettings:toggleSyncRetainEmptyShelves()
+    self.data.sync_retain_empty_shelves = not self:getSyncRetainEmptyShelves()
     self:write()
 end
 

--- a/grimmory.koplugin/grimmory/settings.lua
+++ b/grimmory.koplugin/grimmory/settings.lua
@@ -34,6 +34,8 @@ local logger = GrimmoryLogger:new()
 ---@field sync_download_directory string
 ---@field sync_reading_sessions boolean
 ---@field sync_reading_progress boolean
+---@field sync_shelves_as_collections boolean
+---@field sync_empty_shelves boolean
 ---@field device_id string
 ---@field device_name string
 
@@ -56,6 +58,8 @@ local DEFAULTS = {
     sync_download_directory = "grimmory/",
     sync_reading_sessions = true,
     sync_reading_progress = true,
+    sync_shelves_as_collections = true,
+    sync_empty_shelves = false,
     device_id = random.uuid(),
     device_name = Device.model,
 }
@@ -241,6 +245,32 @@ end
 
 function GrimmorySettings:toggleSyncReadingSessions()
     self.data.sync_reading_sessions = not self.data.sync_reading_sessions
+    self:write()
+end
+
+function GrimmorySettings:getSyncShelves()
+    if self.data.sync_shelves_as_collections == nil then
+        return DEFAULTS.sync_shelves_as_collections
+    end
+
+    return self.data.sync_shelves_as_collections
+end
+
+function GrimmorySettings:toggleSyncShelves()
+    self.data.sync_shelves_as_collections = not self:getSyncShelves()
+    self:write()
+end
+
+function GrimmorySettings:getSyncEmptyShelves()
+    if self.data.sync_empty_shelves == nil then
+        return DEFAULTS.sync_empty_shelves
+    end
+
+    return self.data.sync_empty_shelves
+end
+
+function GrimmorySettings:toggleSyncEmptyShelves()
+    self.data.sync_empty_shelves = not self:getSyncEmptyShelves()
     self:write()
 end
 

--- a/grimmory.koplugin/grimmory/synchronize.lua
+++ b/grimmory.koplugin/grimmory/synchronize.lua
@@ -211,7 +211,7 @@ function GrimmorySynchronize:isTargetShelf(shelf_id)
 end
 
 function GrimmorySynchronize:synchronizeShelves(callback)
-    if not self.settings:getDownloadsBooks() then
+    if not self.settings:getSyncShelves() then
         logger:info("Shelf sync skipped because feature is disabled")
         return
     end
@@ -228,7 +228,7 @@ function GrimmorySynchronize:synchronizeShelves(callback)
 
     -- Make sure we have our unique shelf names and ID mappings
     for _, shelf in ipairs(shelves) do
-        if shelf.id and shelf.name and self:isTargetShelf(shelf.id) then
+        if shelf.id and shelf.name then
             local shelf_name = shelf.name
 
             logger:dbg("Shelf received from Grimmory", shelf.id, shelf_name)
@@ -327,6 +327,35 @@ function GrimmorySynchronize:synchronizeShelves(callback)
                 shelf_id = shelf_id,
                 shelf_name = shelf_name,
             })
+        end
+    end
+
+    -- Persist collections to the database now that we've finished our sync
+    ReadCollection:write()
+end
+
+function GrimmorySynchronize:removeEmptyShelves(callback)
+    if self.settings:getSyncEmptyShelves() then
+        logger:info("Shelf clean up sync skipped because feature is disabled")
+        return
+    end
+
+    -- Read through existing collections and compare against shelves
+    for collection_name, _ in pairs(ReadCollection.coll) do
+        local shelf_id = ReadCollection.coll_settings[collection_name].connectorId
+        local books = ReadCollection:getOrderedCollection(collection_name)
+
+        if shelf_id and #books == 0 then
+            -- This is a grimmory shelf and is empty
+            logger:info("Removing empty shelf:", collection_name)
+
+            callback({
+                state = "shelf-remove",
+                shelf_id = shelf_id,
+                shelf_name = collection_name,
+            })
+
+            ReadCollection:removeCollection(collection_name)
         end
     end
 
@@ -446,7 +475,7 @@ function GrimmorySynchronize:associateWithShelves(book_path, shelves)
             remote_shelves[collection_name] = true
 
             if not local_shelves[collection_name] then
-                logger:dbg("Adding book to collection:", book_path, collection_name)
+                logger:info("Adding book to collection:", book_path, collection_name)
                 ReadCollection:addItem(book_path, collection_name)
             end
         end
@@ -455,7 +484,7 @@ function GrimmorySynchronize:associateWithShelves(book_path, shelves)
     -- Remove any current collections that are not current shelves.
     for collection_name, _ in pairs(local_shelves) do
         if not remote_shelves[collection_name] then
-            logger:dbg("Removing book from collection:", book_path, collection_name)
+            logger:info("Removing book from collection:", book_path, collection_name)
             ReadCollection:removeItem(book_path, collection_name)
         end
     end
@@ -590,6 +619,9 @@ function GrimmorySynchronize:synchronizeAll(callback)
     -- reading progress may change the books we sync down
     logger:info("Pulling books")
     self:pullBooks(callback)
+
+    -- Clean up empty shelves
+    self:removeEmptyShelves(callback)
 
     logger:info("Done synchronizing")
 end

--- a/grimmory.koplugin/grimmory/synchronize.lua
+++ b/grimmory.koplugin/grimmory/synchronize.lua
@@ -452,6 +452,8 @@ function GrimmorySynchronize:getBookDownloadPath(book)
     return download_path
 end
 
+---@param book_path string
+---@param shelves integer[]
 function GrimmorySynchronize:associateWithShelves(book_path, shelves)
     local local_shelves = {}
     local shelf_id_to_name = {}
@@ -475,7 +477,7 @@ function GrimmorySynchronize:associateWithShelves(book_path, shelves)
             remote_shelves[collection_name] = true
 
             if not local_shelves[collection_name] then
-                logger:info("Adding book to collection:", book_path, collection_name)
+                logger:dbg("Adding book to collection:", book_path, collection_name)
                 ReadCollection:addItem(book_path, collection_name)
             end
         end
@@ -484,7 +486,7 @@ function GrimmorySynchronize:associateWithShelves(book_path, shelves)
     -- Remove any current collections that are not current shelves.
     for collection_name, _ in pairs(local_shelves) do
         if not remote_shelves[collection_name] then
-            logger:info("Removing book from collection:", book_path, collection_name)
+            logger:dbg("Removing book from collection:", book_path, collection_name)
             ReadCollection:removeItem(book_path, collection_name)
         end
     end
@@ -534,7 +536,7 @@ function GrimmorySynchronize:pullBook(book, callback)
     if book_exists and download_path then
         -- After we're done, if the book exists we should attach it
         -- to associated shelves.
-        self:associateWithShelves(download_path, book.shelves)
+        self:associateWithShelves(download_path, book.shelves or {})
         self.repository:upsertBook(download_path, book.id)
     end
 

--- a/grimmory.koplugin/grimmory/synchronize.lua
+++ b/grimmory.koplugin/grimmory/synchronize.lua
@@ -335,7 +335,7 @@ function GrimmorySynchronize:synchronizeShelves(callback)
 end
 
 function GrimmorySynchronize:removeEmptyShelves(callback)
-    if self.settings:getSyncEmptyShelves() then
+    if self.settings:getSyncRetainEmptyShelves() then
         logger:info("Shelf clean up sync skipped because feature is disabled")
         return
     end

--- a/grimmory.koplugin/grimmory/ui/menu.lua
+++ b/grimmory.koplugin/grimmory/ui/menu.lua
@@ -170,6 +170,30 @@ function GrimmoryMenu:getSyncOptionsMenu()
                 self.settings:toggleSyncReadingProgress()
                 UIManager:broadcastEvent(Event:new("GrimmorySettingsChanged"))
             end,
+            separator = true,
+        },
+        {
+            text = _("Sync Shelves"),
+            checked_func = function()
+                return self.settings:getSyncShelves()
+            end,
+            callback = function()
+                self.settings:toggleSyncShelves()
+                UIManager:broadcastEvent(Event:new("GrimmorySettingsChanged"))
+            end,
+        },
+        {
+            text = _("Sync Empty Shelves"),
+            enabled_func = function()
+                return self.settings:getSyncShelves()
+            end,
+            checked_func = function()
+                return self.settings:getSyncShelves() and self.settings:getSyncEmptyShelves()
+            end,
+            callback = function()
+                self.settings:toggleSyncEmptyShelves()
+                UIManager:broadcastEvent(Event:new("GrimmorySettingsChanged"))
+            end,
         },
     }
 end


### PR DESCRIPTION
reworks the shelf creation code to instead add all shelves as collections attached to a book when shelf sync is enabled, and removing shelves that are no longer relevant

fixes #124

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added "Sync Shelves" setting to control whether shelves are synced as collections
* Added "Sync Empty Shelves" option to automatically remove empty collections during synchronization
* New menu controls available for toggling shelf sync preferences

<!-- end of auto-generated comment: release notes by coderabbit.ai -->