### PR TITLE
fix: always refresh read collection at the end of syncs

### DIFF
--- a/grimmory.koplugin/main.lua
+++ b/grimmory.koplugin/main.lua
@@ -517,7 +517,8 @@ function Grimmory:onGrimmorySync(verbose, book_path)
         -- event so the file manager knows it should refresh
         UIManager:broadcastEvent(Event:new("RefreshContent"))
 
-        -- Also refresh collections in this process
+        -- Also force refresh collections in this process
+        ReadCollection.last_read_time = 0
         ReadCollection:_read()
 
         if verbose then


### PR DESCRIPTION
the read collection may not always refresh at the end of a sync because internally it refuses to refresh if the writes and reads happened in the same second