### PR TITLE
refactor: convert book page fetching to an iterator

### DIFF
--- a/grimmory.koplugin/grimmory/grimmory_api.lua
+++ b/grimmory.koplugin/grimmory/grimmory_api.lua
@@ -353,28 +353,6 @@ function GrimmoryAPI:getServerVersion()
 end
 
 ---@return boolean ok
----@return Book[] | string
-function GrimmoryAPI:getBooks()
-    local ok, _, body = self:request(
-        "GET",
-        "/api/v1/books?stripForListView=false"
-    )
-
-    if not ok or type(body) == "string" then
-        logger:err("Could not get books", body)
-        return ok, body
-    end
-
-    local books = {}
-
-    for _, raw_book in ipairs(body) do
-        table.insert(books, parseBook(raw_book))
-    end
-
-    return ok, books
-end
-
----@return boolean ok
 ---@return Book[] | string page_books
 ---@return number total_count
 function GrimmoryAPI:getBooksPage(page_number)
@@ -402,6 +380,54 @@ function GrimmoryAPI:getBooksPage(page_number)
     end
 
     return ok, books, total_count
+end
+
+---@return (fun(): (Book | nil, integer, integer))
+function GrimmoryAPI:getBooks()
+    local page = 0
+    local batch_index = 0
+    local book_index = 0
+
+    local books_ok, books_batch, total_books = self:getBooksPage(page)
+
+    if not books_ok then
+        logger:err("Unable to read books:", books_batch)
+        return function()
+            return nil, 0, 0
+        end
+    end
+
+    return function ()
+        if type(books_batch) ~= "table" or #books_batch == 0 then
+            return nil, book_index, total_books
+        end
+
+        if batch_index >= #books_batch then
+            -- If current_index is past the current batch
+            page = page + 1
+
+            local new_books_ok, new_books_batch, new_total_books = self:getBooksPage(page)
+            batch_index = 0
+
+            if not new_books_ok or type(new_books_batch) ~= "table" then
+                logger:err("Unable to read books:", new_books_batch)
+
+                -- Set the books batch to empty so we basically stop iteration
+                books_batch = {}
+
+                return nil, book_index, total_books
+            end
+
+            books_batch = new_books_batch
+            total_books = new_total_books
+        end
+
+        batch_index = batch_index + 1
+        book_index = book_index + 1
+
+        return books_batch[batch_index], book_index, total_books
+    end
+
 end
 
 function GrimmoryAPI:downloadBook(book_id, destination_path)

--- a/grimmory.koplugin/grimmory/synchronize.lua
+++ b/grimmory.koplugin/grimmory/synchronize.lua
@@ -532,53 +532,28 @@ function GrimmorySynchronize:pullBooks(callback)
         return
     end
 
-    local page = 0
-    local element_count = 0
-
-    while true do
-        logger:dbg("Fetching books to pull, page:", page)
-
-        local books_ok, books_batch, total_books = self.api:getBooksPage(page)
-
-        callback({
-            state = "book-page",
-            page = 0,
-            viewed_books = element_count,
-            total_books = total_books,
-        })
-
-        if books_ok and type(books_batch) == "table" then
-            if #books_batch == 0 then
-                break
+    for book, element_count, total_books in self.api:getBooks() do
+        if self:isTargetBook(book) then
+            local pull_ok, pull_path_or_message = pcall(self.pullBook, self, book, callback)
+            if pull_ok then
+                callback({
+                    state = "book-downloaded",
+                    book_id = book.id,
+                    download_path = pull_path_or_message,
+                    viewed_books = element_count,
+                    total_books = total_books,
+                })
+            else
+                logger:err("Book failed to pull:", book.id, "-", pull_path_or_message)
+                callback({
+                    state = "book-error",
+                    book_id = book.id,
+                    message = pull_path_or_message,
+                    viewed_books = element_count,
+                    total_books = total_books,
+                })
             end
-
-            for _, book in ipairs(books_batch) do
-                if self:isTargetBook(book) then
-                    local pull_ok, pull_path_or_message = pcall(self.pullBook, self, book, callback)
-                    if pull_ok then
-                        callback({
-                            state = "book-downloaded",
-                            book_id = book.id,
-                            download_path = pull_path_or_message,
-                        })
-                    else
-                        logger:err("Book failed to pull:", book.id, "-", pull_path_or_message)
-                        callback({
-                            state = "book-error",
-                            book_id = book.id,
-                            message = pull_path_or_message,
-                        })
-                    end
-                end
-
-                element_count = element_count + 1
-            end
-        else
-            logger:err("Something went wrong reading books from server, stopping book sync")
-            break
         end
-
-        page = page + 1
     end
 
     -- During pulling books we may have updated the collections that

--- a/grimmory.koplugin/main.lua
+++ b/grimmory.koplugin/main.lua
@@ -447,7 +447,7 @@ function Grimmory:onGrimmorySync(verbose, book_path)
                     update_progress_step(3)
                 end
 
-                if progress.state == "book-page" then
+                if progress.state == "book-downloaded" or progress.state == "book-error" then
                     local viewed_books = progress.viewed_books or 0
                     local total_books = progress.total_books or 0
 


### PR DESCRIPTION
refactors the book reading to abstract the pagination away behind an iterator - this will be used to more easily scan all books

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized book fetching process for improved handling of large libraries
  * Enhanced synchronization progress tracking for more accurate status reporting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->