### PR TITLE
fix: automatically find grimmory ID when syncing individual book

### DIFF
--- a/grimmory.koplugin/grimmory/repository.lua
+++ b/grimmory.koplugin/grimmory/repository.lua
@@ -215,7 +215,7 @@ function GrimmoryLocalRepository:upsertBook(book_path, grimmory_id)
 
     if not ok or not book then
         logger:err("Failed to upsert book:", book_path, "-", book)
-        return false, nil
+        return false, nil, nil
     end
 
     return true, book.id, book.grimmory_id

--- a/grimmory.koplugin/grimmory/repository.lua
+++ b/grimmory.koplugin/grimmory/repository.lua
@@ -147,10 +147,11 @@ end
 ---@param grimmory_id number | nil
 ---@return boolean ok
 ---@return integer | nil book_id
+---@return integer | nil grimmory_id
 function GrimmoryLocalRepository:upsertBook(book_path, grimmory_id)
     local partial_md5 = util.partialMD5(book_path)
 
-    local ok, book_id = self:withDatabase(
+    local ok, book = self:withDatabase(
         function(conn)
             -- Remember that `OR IGNORE` will ignore almost all
             -- data type or constraint failures.
@@ -188,7 +189,9 @@ function GrimmoryLocalRepository:upsertBook(book_path, grimmory_id)
             local book_id = tonumber(row[1])
             local existing_grimmory_id = tonumber(row[2])
 
-            if existing_grimmory_id ~= grimmory_id and grimmory_id ~= nil then
+            if grimmory_id == nil then
+                grimmory_id = existing_grimmory_id
+            elseif existing_grimmory_id ~= grimmory_id then
                 local update_stmt = conn:prepare([[
                     UPDATE book
                     SET
@@ -202,17 +205,20 @@ function GrimmoryLocalRepository:upsertBook(book_path, grimmory_id)
                 update_stmt:close()
             end
 
-            return book_id
+            return {
+                id = book_id,
+                grimmory_id = grimmory_id,
+            }
         end,
         "rw"
     )
 
-    if not ok or not book_id then
-        logger:err("Failed to upsert book:", book_path, "-", book_id)
+    if not ok or not book then
+        logger:err("Failed to upsert book:", book_path, "-", book)
         return false, nil
     end
 
-    return true, book_id
+    return true, book.id, book.grimmory_id
 end
 
 ---@param book_path string

--- a/grimmory.koplugin/grimmory/synchronize.lua
+++ b/grimmory.koplugin/grimmory/synchronize.lua
@@ -90,6 +90,13 @@ function GrimmorySynchronize:pushBookSessions(book_id, callback)
                 bookPath = session.book_path,
                 since = session.end_time,
             })
+        elseif session.grimmory_id == nil then
+            logger:err("Session failed recording with error for book: ", book_id, " - ", "No Grimmory ID")
+            callback({
+                state = "session-error",
+                bookPath = session.book_path,
+                since = session.end_time,
+            })
         else
             logger:dbg(
                 "Recording session",

--- a/grimmory.koplugin/grimmory/synchronize.lua
+++ b/grimmory.koplugin/grimmory/synchronize.lua
@@ -520,7 +520,12 @@ end
 function GrimmorySynchronize:associateBook(book_path)
     for book in self.api:getBooks() do
         if self.doc_metadata:isBook(book_path, book) then
-            self.repository:upsertBook(book_path, book.id)
+            local ok = self.repository:upsertBook(book_path, book.id)
+
+            if not ok then
+                logger:err("Failed to write book association:", book_path)
+            end
+
             return true
         end
     end

--- a/grimmory.koplugin/grimmory/synchronize.lua
+++ b/grimmory.koplugin/grimmory/synchronize.lua
@@ -512,6 +512,18 @@ function GrimmorySynchronize:associateWithShelves(book_path, shelves)
     end
 end
 
+---@param book_path string
+---@return boolean found
+function GrimmorySynchronize:associateBook(book_path)
+    for book in self.api:getBooks() do
+        if self.doc_metadata:isBook(book_path, book) then
+            self.repository:upsertBook(book_path, book.id)
+            return true
+        end
+    end
+
+    return false
+end
 
 ---@param book Book
 ---@return string download_path
@@ -709,10 +721,21 @@ function GrimmorySynchronize:synchronizeBook(book_path, callback)
     end
 
     -- Get book ID
-    local book_ok, book_id = self.repository:upsertBook(book_path)
+    local book_ok, book_id, grimmory_id = self.repository:upsertBook(book_path)
 
     if not book_ok or not book_id then
         error("Could not track book")
+    end
+
+    if grimmory_id == nil then
+        -- Try to find a grimmory ID for this book
+        logger:info("Searching Grimmory for book:", book_path)
+
+        if self:associateBook(book_path) then
+            logger:info("Found book in Grimmory:", book_path)
+        else
+            logger:warn("Unable to locate book in Grimmory:", book_path)
+        end
     end
 
     -- First, tell Grimmory about all of our reading

--- a/grimmory.koplugin/grimmory/synchronize.lua
+++ b/grimmory.koplugin/grimmory/synchronize.lua
@@ -95,8 +95,11 @@ function GrimmorySynchronize:pushBookSessions(book_id, callback)
             callback({
                 state = "session-error",
                 bookPath = session.book_path,
-                since = session.end_time,
             })
+
+            -- If an error happens for this session we bail early so
+            -- retries can happen again later
+            break
         else
             logger:dbg(
                 "Recording session",


### PR DESCRIPTION
if the grimmory ID is not specified, we should try to find a grimmory ID

related to #119

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic book matching that associates local books with your remote library during synchronization.
  * Upgraded tracking so synchronization now returns and preserves remote book identifiers.

* **Bug Fixes**
  * Better handling of pending sessions missing remote IDs: logs error, reports session errors, and halts processing for that book.
  * Improved error reporting and recovery when book tracking or association fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->