### PR TITLE
fix: only use existing file paths that exist

### DIFF
--- a/grimmory.koplugin/grimmory/repository.lua
+++ b/grimmory.koplugin/grimmory/repository.lua
@@ -18,6 +18,12 @@ local function getPluginPath()
     return path
 end
 
+---@class GrimmoryLocalBook
+---@field id integer
+---@field book_md5 string
+---@field book_path string
+---@field grimmory_id integer | nil
+
 ---@alias ReadingSessionEventType
 ---| "page"
 ---| "session-start"
@@ -258,13 +264,13 @@ end
 
 ---@param grimmory_id number
 ---@return boolean ok
----@return string | nil book_path
----@return string | nil book_md5
-function GrimmoryLocalRepository:findBookByGrimmoryId(grimmory_id)
-    local ok, book = self:withDatabase(
+---@return GrimmoryLocalBook[] books
+function GrimmoryLocalRepository:findBooksByGrimmoryId(grimmory_id)
+    local ok, books = self:withDatabase(
         function(conn)
             local select_stmt = conn:prepare([[
                 SELECT
+                    id,
                     book_path,
                     partial_md5
                 FROM book
@@ -273,31 +279,32 @@ function GrimmoryLocalRepository:findBookByGrimmoryId(grimmory_id)
             ]])
 
             select_stmt:bind(grimmory_id)
-            local row = select_stmt:step()
-            select_stmt:close()
 
-            if not row then
-                return error("Not Found")
+            local books = {}
+
+            for row in select_stmt:rows() do
+                table.insert(
+                    books,
+                    {
+                        id = tonumber(row[1]),
+                        book_path = row[2],
+                        book_md5 = row[3],
+                    }
+                )
             end
 
-            return {
-                book_path = row[1],
-                book_md5 = row[2],
-            }
+            select_stmt:close()
+
+            return books
         end
     )
 
     if not ok then
-        logger:err("Failed to find book:", grimmory_id, "-", book)
-        return false, nil, nil
+        logger:err("Failed to find book:", grimmory_id, "-", books)
+        return false, {}
     end
 
-    if not book then
-        logger:dbg("Book query succees but did not find book:", grimmory_id)
-        return true, nil, nil
-    end
-
-    return true, book.book_path, book.book_md5
+    return true, books
 end
 
 ---@param book_id number

--- a/grimmory.koplugin/grimmory/synchronize.lua
+++ b/grimmory.koplugin/grimmory/synchronize.lua
@@ -404,7 +404,10 @@ function GrimmorySynchronize:getBookDownloadPath(book)
     local existing_book_ok, existing_books = self.repository:findBooksByGrimmoryId(book.id)
     if existing_book_ok then
         for _, local_book in ipairs(existing_books) do
-            if util.fileExists(local_book.book_path) and util.partialMD5(local_book.book_path) == local_book.book_md5 then
+            if (
+                util.fileExists(local_book.book_path) and
+                util.partialMD5(local_book.book_path) == local_book.book_md5
+            ) then
                 return local_book.book_path
             end
         end

--- a/grimmory.koplugin/grimmory/synchronize.lua
+++ b/grimmory.koplugin/grimmory/synchronize.lua
@@ -403,9 +403,9 @@ end
 function GrimmorySynchronize:getBookDownloadPath(book)
     local existing_book_ok, existing_books = self.repository:findBooksByGrimmoryId(book.id)
     if existing_book_ok then
-        for _, book in ipairs(existing_books) do
-            if util.fileExists(book.book_path) and util.partialMD5(book.book_path) == book.book_md5 then
-                return book.book_path
+        for _, local_book in ipairs(existing_books) do
+            if util.fileExists(local_book.book_path) and util.partialMD5(local_book.book_path) == local_book.book_md5 then
+                return local_book.book_path
             end
         end
     end

--- a/grimmory.koplugin/grimmory/synchronize.lua
+++ b/grimmory.koplugin/grimmory/synchronize.lua
@@ -401,9 +401,13 @@ end
 ---@param book Book
 ---@return string download_path
 function GrimmorySynchronize:getBookDownloadPath(book)
-    local existing_book_ok, existing_book_path = self.repository:findBookByGrimmoryId(book.id)
-    if existing_book_ok and existing_book_path then
-        return existing_book_path
+    local existing_book_ok, existing_books = self.repository:findBooksByGrimmoryId(book.id)
+    if existing_book_ok then
+        for _, book in ipairs(existing_books) do
+            if util.fileExists(book.book_path) and util.partialMD5(book.book_path) == book.book_md5 then
+                return book.book_path
+            end
+        end
     end
 
     local download_directory = self.settings:getDownloadDirectory()


### PR DESCRIPTION
only use paths from the database for an existing file when the file still exists and has the right checksum

related to #119

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved book matching logic to handle multiple candidate books for the same ID, ensuring correct book resolution through file existence and checksum verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->