### PR TITLE
feat: add extra_headers setting and use in API

### DIFF
--- a/grimmory.koplugin/grimmory/grimmory_api.lua
+++ b/grimmory.koplugin/grimmory/grimmory_api.lua
@@ -175,6 +175,10 @@ function GrimmoryAPI:rawRequest(method, uri, data, headers, sink)
 
     headers["User-Agent"] = getUserAgent()
 
+    for key, value in pairs(self.settings:getExtraHeaders()) do
+        headers[key] = value
+    end
+
     local client
     if uri:match("^http:") then
         client = http

--- a/grimmory.koplugin/grimmory/settings.lua
+++ b/grimmory.koplugin/grimmory/settings.lua
@@ -21,6 +21,7 @@ local logger = GrimmoryLogger:new()
 ---@field base_uri string
 ---@field username string
 ---@field password string
+---@field extra_headers { [string]: string }
 ---@field session_threshold_seconds number
 ---@field session_threshold_pages number
 ---@field sync_on_close_document boolean
@@ -43,6 +44,7 @@ local logger = GrimmoryLogger:new()
 ---@type GrimmorySettingsData
 local DEFAULTS = {
     automatic_check_updates = false,
+    extra_headers = {},
     base_uri = "",
     username = "",
     password = "",
@@ -150,6 +152,15 @@ end
 function GrimmorySettings:setBaseUri(uri)
     uri = tostring(uri or ""):gsub("/*$", "")
     self.data.base_uri = uri
+    self:write()
+end
+
+function GrimmorySettings:getExtraHeaders()
+    return self.data.extra_headers or DEFAULTS.extra_headers
+end
+
+function GrimmorySettings:setExtraHeaders(headers)
+    self.data.extra_headers = headers
     self:write()
 end
 


### PR DESCRIPTION
Adds the `extra_headers` settings option which can be specified as:

```
    ["extra_headers"] = {
        ["Magic"] = "Value"
    }
```

fixes #134

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom HTTP headers in API requests.
  * New settings option to configure and manage extra headers for outgoing requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->