### PR TITLE
fix: remove books from shelves when dropped in grimmory

### DIFF
--- a/grimmory.koplugin/grimmory/synchronize.lua
+++ b/grimmory.koplugin/grimmory/synchronize.lua
@@ -650,39 +650,45 @@ function GrimmorySynchronize:pullBooks(callback)
     util.findFiles(
         download_directory,
         function(path)
-            if path:match("%.sdr/") then
-                -- Ignore sidecar directory
-                return
-            end
+            local ok, result = pcall(function()
+                if path:match("%.sdr/") then
+                    -- Ignore sidecar directory
+                    return
+                end
 
-            if seen_books[path] then
-                -- We saw this specific file and can skip
-                -- We don't need to do the database lookup
-                return
-            end
+                if seen_books[path] then
+                    -- We saw this specific file and can skip
+                    -- We don't need to do the database lookup
+                    return
+                end
 
-            local partial_md5 = util.partialMD5(path)
-            local found_ok, _, grimmory_id = self.repository:findBookByFile(path, partial_md5)
+                local partial_md5 = util.partialMD5(path)
+                local found_ok, _, grimmory_id = self.repository:findBookByFile(path, partial_md5)
 
-            if not found_ok or not grimmory_id then
-                -- Skip file, not tracked in database for some reason
-                logger:dbg("Skipping file removal, not in database:", path, partial_md5)
-                return
-            end
+                if not found_ok or not grimmory_id then
+                    -- Skip file, not tracked in database for some reason
+                    logger:dbg("Skipping file removal, not in database:", path, partial_md5)
+                    return
+                end
 
-            if seen_grimmory_ids[tostring(grimmory_id)] then
-                -- We saw this Grimmory ID as a valid book to keep on-device.
-                return
-            end
+                if seen_grimmory_ids[tostring(grimmory_id)] then
+                    -- We saw this Grimmory ID as a valid book to keep on-device.
+                    return
+                end
 
-            logger:dbg("Book removed from upstream:", path)
+                logger:dbg("Book removed from upstream:", path)
 
-            if self.settings:getDownloadRemoveBooks() then
-                self:removeBook(path)
-            else
-                -- Even if we don't remove the book we should remove it
-                -- from all Grimmory shelves.
-                self:associateWithShelves(path, {})
+                if self.settings:getDownloadRemoveBooks() then
+                    self:removeBook(path)
+                else
+                    -- Even if we don't remove the book we should remove it
+                    -- from all Grimmory shelves.
+                    self:associateWithShelves(path, {})
+                end
+            end)
+
+            if not ok then
+                logger:err("Failed during cleanup:", path, "-", result)
             end
         end,
         true

--- a/grimmory.koplugin/grimmory/synchronize.lua
+++ b/grimmory.koplugin/grimmory/synchronize.lua
@@ -643,44 +643,50 @@ function GrimmorySynchronize:pullBooks(callback)
         end
     end
 
-    if self.settings:getDownloadRemoveBooks() then
-        logger:dbg("Checking if any books need to be removed")
+    logger:dbg("Checking existing books on disk in download directory")
 
-        -- Iterate through books in download directory and
-        -- remove when not in the `seen_books` set
-        util.findFiles(
-            download_directory,
-            function(path)
-                if path:match("%.sdr/") then
-                    -- Ignore sidecar directory
-                    return
-                end
+    -- Iterate through books in download directory and
+    -- remove when not in the `seen_books` set
+    util.findFiles(
+        download_directory,
+        function(path)
+            if path:match("%.sdr/") then
+                -- Ignore sidecar directory
+                return
+            end
 
-                if seen_books[path] then
-                    -- We saw this specific file and can skip
-                    -- We don't need to do the database lookup
-                    return
-                end
+            if seen_books[path] then
+                -- We saw this specific file and can skip
+                -- We don't need to do the database lookup
+                return
+            end
 
-                local partial_md5 = util.partialMD5(path)
-                local found_ok, _, grimmory_id = self.repository:findBookByFile(path, partial_md5)
+            local partial_md5 = util.partialMD5(path)
+            local found_ok, _, grimmory_id = self.repository:findBookByFile(path, partial_md5)
 
-                if not found_ok or not grimmory_id then
-                    -- Skip file, not tracked in database for some reason
-                    logger:dbg("Skipping file removal, not in database:", path, partial_md5)
-                    return
-                end
+            if not found_ok or not grimmory_id then
+                -- Skip file, not tracked in database for some reason
+                logger:dbg("Skipping file removal, not in database:", path, partial_md5)
+                return
+            end
 
-                if seen_grimmory_ids[tostring(grimmory_id)] then
-                    -- We saw this Grimmory ID as a valid book to keep on-device.
-                    return
-                end
+            if seen_grimmory_ids[tostring(grimmory_id)] then
+                -- We saw this Grimmory ID as a valid book to keep on-device.
+                return
+            end
 
+            logger:dbg("Book removed from upstream:", path)
+
+            if self.settings:getDownloadRemoveBooks() then
                 self:removeBook(path)
-            end,
-            true
-        )
-    end
+            else
+                -- Even if we don't remove the book we should remove it
+                -- from all Grimmory shelves.
+                self:associateWithShelves(path, {})
+            end
+        end,
+        true
+    )
 
     -- During pulling books we may have updated the collections that
     -- books are in which need to be persisted to disk


### PR DESCRIPTION
this updates the behavior for books that were not included in the sync - so that books that are dropped from target shelves or from grimmory entirely will be also removed from Grimmory shelf collections

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization cleanup behavior. Books removed from upstream sources are now properly handled: either deleted from disk when configured, or disassociated from all shelves when automatic removal is disabled. Previously, such books remained unchanged when automatic removal was turned off.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->