### PR TITLE
fix: handle rename of empty shelves setting

### DIFF
--- a/grimmory.koplugin/grimmory/ui/menu.lua
+++ b/grimmory.koplugin/grimmory/ui/menu.lua
@@ -188,10 +188,10 @@ function GrimmoryMenu:getSyncOptionsMenu()
                 return self.settings:getSyncShelves()
             end,
             checked_func = function()
-                return self.settings:getSyncShelves() and self.settings:getSyncEmptyShelves()
+                return self.settings:getSyncShelves() and self.settings:getSyncRetainEmptyShelves()
             end,
             callback = function()
-                self.settings:toggleSyncEmptyShelves()
+                self.settings:toggleSyncRetainEmptyShelves()
                 UIManager:broadcastEvent(Event:new("GrimmorySettingsChanged"))
             end,
         },


### PR DESCRIPTION
the empty shelves setting was renamed but an old reference remained