### PR TITLE
fix: clearer sync messages for users

### DIFF
--- a/grimmory.koplugin/grimmory/synchronize.lua
+++ b/grimmory.koplugin/grimmory/synchronize.lua
@@ -399,12 +399,6 @@ function GrimmorySynchronize:downloadBook(book_id, download_path)
         return false, message
     end
 
-    local progress_ok, progress_result = pcall(self.pullBookProgress, self, download_path)
-
-    if not progress_ok then
-        logger:warn("Could not pull progress for book:", book_id, "-", progress_result)
-    end
-
     return true, nil
 end
 
@@ -535,8 +529,10 @@ end
 
 ---@param book Book
 ---@return string download_path
+---@return boolean is_downloaded
 function GrimmorySynchronize:pullBook(book)
     local book_exists = false
+    local is_downloaded = false
 
     local download_path = self:getBookDownloadPath(book)
 
@@ -549,6 +545,8 @@ function GrimmorySynchronize:pullBook(book)
 
     if not book_exists then
         if download_path ~= nil then
+            is_downloaded = true
+
             logger:dbg("Downloading book", book.id, "to", download_path)
 
             local ok, message = self:downloadBook(book.id, download_path)
@@ -564,13 +562,15 @@ function GrimmorySynchronize:pullBook(book)
     end
 
     if book_exists and download_path then
-        -- After we're done, if the book exists we should attach it
-        -- to associated shelves.
-        self:associateWithShelves(download_path, book.shelves or {})
         self.repository:upsertBook(download_path, book.id)
+
+        -- After we're done, if the book exists we should attach it
+        -- to associated shelves and pull the book progress.
+        self:associateWithShelves(download_path, book.shelves or {})
+        self:pullBookProgress(download_path)
     end
 
-    return download_path
+    return download_path, is_downloaded
 end
 
 ---@param book_path string
@@ -619,17 +619,27 @@ function GrimmorySynchronize:pullBooks(callback)
         if self:isTargetBook(book) then
             seen_grimmory_ids[tostring(book.id)] = true
 
-            local pull_ok, pull_path_or_message = pcall(self.pullBook, self, book, callback)
+            local pull_ok, pull_path_or_message, is_downloaded = pcall(self.pullBook, self, book, callback)
             if pull_ok then
                 seen_books[pull_path_or_message] = true
 
-                callback({
-                    state = "book-downloaded",
-                    book_id = book.id,
-                    download_path = pull_path_or_message,
-                    viewed_books = element_count,
-                    total_books = total_books,
-                })
+                if is_downloaded then
+                    callback({
+                        state = "book-downloaded",
+                        book_id = book.id,
+                        book_path = pull_path_or_message,
+                        viewed_books = element_count,
+                        total_books = total_books,
+                    })
+                else
+                    callback({
+                        state = "book-pull-metadata",
+                        book_id = book.id,
+                        book_path = pull_path_or_message,
+                        viewed_books = element_count,
+                        total_books = total_books,
+                    })
+                end
             else
                 logger:err("Book failed to pull:", book.id, "-", pull_path_or_message)
                 callback({
@@ -751,18 +761,14 @@ function GrimmorySynchronize:synchronizeBook(book_path, callback)
     self:pushBookMetadata(book_id, callback)
 
     callback({
-        state = "push-book-metadata",
+        state = "book-push-metadata",
         book_id = book_id,
         pushed_books = 1,
         total_books = 1,
     })
 
     -- Then, try to get progress
-    local progress_ok, progress_result = pcall(self.pullBookProgress, self, book_path)
-
-    if not progress_ok then
-        logger:warn("Could not pull progress for book:", book_path, "-", progress_result)
-    end
+    self:pullBookProgress(book_path)
 
     logger:info("Done synchronizing book:", book_path)
 end

--- a/grimmory.koplugin/main.lua
+++ b/grimmory.koplugin/main.lua
@@ -392,7 +392,8 @@ function Grimmory:onGrimmorySync(verbose, book_path)
         local last_progress_step = 0
         local session_count = 0
         local session_error_count = 0
-        local book_count = 0
+        local book_download_count = 0
+        local book_refresh_count = 0
         local book_error_count = 0
 
         local update_progress_step = function(progress_step)
@@ -428,7 +429,7 @@ function Grimmory:onGrimmorySync(verbose, book_path)
                     return
                 end
 
-                if progress.state == "push-book-metadata" then
+                if progress.state == "book-push-metadata" then
                     local pushed_books = progress.pushed_books or 0
                     local total_books = progress.total_books or 0
 
@@ -447,7 +448,11 @@ function Grimmory:onGrimmorySync(verbose, book_path)
                     update_progress_step(3)
                 end
 
-                if progress.state == "book-downloaded" or progress.state == "book-error" then
+                if (
+                    progress.state == "book-downloaded" or
+                    progress.state == "book-error" or
+                    progress.state == "book-pull-metadata"
+                ) then
                     local viewed_books = progress.viewed_books or 0
                     local total_books = progress.total_books or 0
 
@@ -465,9 +470,9 @@ function Grimmory:onGrimmorySync(verbose, book_path)
                 elseif progress.state == "session-error" then
                     session_error_count = session_error_count + 1
                 elseif progress.state == "book-downloaded" then
-                    book_count = book_count + 1
+                    book_download_count = book_download_count + 1
 
-                    if book_count % 20 == 0 then
+                    if book_download_count % 20 == 0 then
                         -- If we're updating a lot of books we should
                         -- emit a refresh event every once in a while
                         -- so background refresh sees these come
@@ -480,6 +485,8 @@ function Grimmory:onGrimmorySync(verbose, book_path)
 
                 elseif progress.state == "book-error" then
                     book_error_count = book_error_count + 1
+                elseif progress.state == "book-pull-metadata" then
+                    book_refresh_count = book_refresh_count + 1
                 end
             end
         )
@@ -522,30 +529,31 @@ function Grimmory:onGrimmorySync(verbose, book_path)
         ReadCollection:_read()
 
         if verbose then
-            local message
-            if session_error_count > 0 or book_error_count > 0 then
-                message = T(
-                    _(
-                        "Completed Grimmory sync\n" ..
-                        "%1 session(s) recorded\n" ..
-                        "%2 session(s) failed\n" ..
-                        "%3 book(s) downloaded\n" ..
-                        "%4 book(s) failed"
-                    ),
-                    session_count,
-                    session_error_count,
-                    book_count,
-                    book_error_count
-                )
-            else
-                message = T(
-                    _("Completed Grimmory sync\n%1 session(s) recorded\n%2 book(s) downloaded"),
-                    session_count,
-                    book_count
-                )
+            local message = {
+                _("Completed Grimmory sync")
+            }
+
+            if session_count > 0 then
+                table.insert(message, T(_("%1 session(s) recorded"), session_count))
             end
 
-            self.dialog_manager:toast(message)
+            if session_error_count > 0 then
+                table.insert(message, T(_("%1 session(s) failed"), session_error_count))
+            end
+
+            if book_download_count > 0 then
+                table.insert(message, T(_("%1 book(s) downloaded"), book_download_count))
+            end
+
+            if book_refresh_count > 0 then
+                table.insert(message, T(_("%1 book(s) refreshed"), book_refresh_count))
+            end
+
+            if book_error_count > 0 then
+                table.insert(message, T(_("%1 book(s) failed"), book_error_count))
+            end
+
+            self.dialog_manager:toast(table.concat(message, "\n"))
         end
     end
 


### PR DESCRIPTION
stops the download message for books when only a refresh happens

related #116 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced synchronization logic to accurately distinguish between newly downloaded books and previously cached books
  * Improved progress tracking with separate counters for book downloads and metadata refreshes
  * Streamlined synchronization by removing redundant operations
  * Refined completion messages to display comprehensive operation summaries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->