### PR TITLE
feat: record CFI with session events

### DIFF
--- a/grimmory.koplugin/grimmory/cfi_resolver.lua
+++ b/grimmory.koplugin/grimmory/cfi_resolver.lua
@@ -1,5 +1,4 @@
 local Cache = require("cache")
-local DocumentRegistry = require("document/documentregistry")
 
 local GrimmoryLogger = require("grimmory/logger")
 
@@ -393,15 +392,15 @@ local function split_local_range_cfi_path(cfi)
 end
 
 ---@class GrimmoryCFIResolver
----@field document_path string
----@field document CREDocument
+---@field document string
 ---@field cache Cache
 local GrimmoryCFIResolver = {}
 
----@param document_path string
-function GrimmoryCFIResolver:new(document_path, cache)
+---@param document CREDocument
+---@param cache? Cache
+function GrimmoryCFIResolver:new(document, cache)
     local o = {
-        document_path = document_path,
+        document = document,
         cache = cache or Cache:new({ slots = 8 })
     }
     setmetatable(o, self)
@@ -424,36 +423,19 @@ function GrimmoryCFIResolver:getFragmentHTML(fragment_index)
         return html
     end
 
-    local document = (
-        DocumentRegistry:hasProvider(self.document_path) and
-        DocumentRegistry:openDocument(self.document_path)
-    )
+    -- There has to be a better way to get this..
 
-    if document then
-        local loaded = true
-        if document.loadDocument then
-            loaded = document:loadDocument(true)
+    local source
+    local fragment_html = self.document:getHTMLFromXPointer("/body/DocFragment[" .. tostring(fragment_index) .. "]")
+    for token in tokenize_html(fragment_html) do
+        if token.type == "tag" and token.text == "docfragment" then
+            source = token.raw:match("Source=\"([^\"]+)\"")
+            break
         end
+    end
 
-        if loaded then
-            -- There has to be a better way to get this..
-
-            local source
-            local fragment_html = document:getHTMLFromXPointer("/body/DocFragment[" .. tostring(fragment_index) .. "]")
-            for token in tokenize_html(fragment_html) do
-                if token.type == "tag" and token.text == "docfragment" then
-                    source = token.raw:match("Source=\"([^\"]+)\"")
-                    break
-                end
-            end
-
-            if source then
-                html = document:getDocumentFileContent(source)
-            end
-
-        end
-
-        document:close()
+    if source then
+        html = self.document:getDocumentFileContent(source)
     end
 
     self.cache:insert(fragment_index, html)

--- a/grimmory.koplugin/grimmory/cfi_resolver.lua
+++ b/grimmory.koplugin/grimmory/cfi_resolver.lua
@@ -391,60 +391,9 @@ local function split_local_range_cfi_path(cfi)
     return root .. path_a, root .. path_b
 end
 
----@class GrimmoryCFIResolver
----@field document string
----@field cache Cache
-local GrimmoryCFIResolver = {}
-
----@param document CREDocument
----@param cache? Cache
-function GrimmoryCFIResolver:new(document, cache)
-    local o = {
-        document = document,
-        cache = cache or Cache:new({ slots = 8 })
-    }
-    setmetatable(o, self)
-    self.__index = self
-    o:init()
-    return o
-end
-
-function GrimmoryCFIResolver:init()
-end
-
----@private
----@param fragment_index integer
----@return string | nil html
-function GrimmoryCFIResolver:getFragmentHTML(fragment_index)
-    local html
-
-    html = self.cache:get(fragment_index)
-    if html ~= nil then
-        return html
-    end
-
-    -- There has to be a better way to get this..
-
-    local source
-    local fragment_html = self.document:getHTMLFromXPointer("/body/DocFragment[" .. tostring(fragment_index) .. "]")
-    for token in tokenize_html(fragment_html) do
-        if token.type == "tag" and token.text == "docfragment" then
-            source = token.raw:match("Source=\"([^\"]+)\"")
-            break
-        end
-    end
-
-    if source then
-        html = self.document:getDocumentFileContent(source)
-    end
-
-    self.cache:insert(fragment_index, html)
-
-    return html
-end
-
----@private
-function GrimmoryCFIResolver:cfiLocalPathToFragmentPath(fragment_html, cfi_local_path)
+---@param fragment_html any
+---@param cfi_local_path any
+local function cfi_local_path_to_fragment_path(fragment_html, cfi_local_path)
     local tokens = tokenize_html(fragment_html)
 
     for token in tokens do
@@ -494,11 +443,10 @@ function GrimmoryCFIResolver:cfiLocalPathToFragmentPath(fragment_html, cfi_local
     return "/" .. table.concat(fragment_path_parts, "/") .. character_offset_suffix
 end
 
----@private
 ---@param fragment_html string
 ---@param fragment_path XPointerFragmentPart[]
 ---@return string cfi_local_path
-function GrimmoryCFIResolver:fragmentPathToCFILocalPath(fragment_html, fragment_path)
+local function fragment_path_to_cfi_local_path(fragment_html, fragment_path)
     if #fragment_path == 0 or #fragment_html == 0 then
         return "/1"
     end
@@ -558,24 +506,78 @@ function GrimmoryCFIResolver:fragmentPathToCFILocalPath(fragment_html, fragment_
     return "/" .. table.concat(cfi_steps, "/") .. character_offset_suffix
 end
 
----@private
+---@class GrimmoryCFIResolver
+---@field document string
+---@field cache Cache
+local GrimmoryCFIResolver = {}
+
+---@param document CREDocument
+---@param cache? Cache
+function GrimmoryCFIResolver:new(document, cache)
+    local o = {
+        document = document,
+        cache = cache or Cache:new({ slots = 8 })
+    }
+    setmetatable(o, self)
+    self.__index = self
+    o:init()
+    return o
+end
+
+function GrimmoryCFIResolver:init()
+end
+
 ---@param cfi_a string
 ---@param cfi_b string
----@return string local_range_path
-function GrimmoryCFIResolver:getLocalRangeCFIPath(cfi_a, cfi_b)
+---@return string
+function GrimmoryCFIResolver.asCFIRange(cfi_a, cfi_b)
+    local bare_cfi_a = cfi_a:match("^epubcfi%((.+)%)$")
+    local bare_cfi_b = cfi_b:match("^epubcfi%((.+)%)$")
+
     local root = ""
 
-    for step in cfi_a:gmatch("([^/]+)") do
+    for step in bare_cfi_a:gmatch("([^/]+)") do
         local next = root .. "/" .. step .. "/"
 
-        if next ~= cfi_b:sub(1, #next) then
+        if next ~= bare_cfi_b:sub(1, #next) then
             break
         end
 
         root = root .. "/" .. step
     end
 
-    return root .. "," .. cfi_a:sub(#root + 1) .. "," .. cfi_b:sub(#root + 1)
+    return "epubcfi(" .. root .. "," .. bare_cfi_a:sub(#root + 1) .. "," .. bare_cfi_b:sub(#root + 1) .. ")"
+end
+
+---@private
+---@param fragment_index integer
+---@return string | nil html
+function GrimmoryCFIResolver:getFragmentHTML(fragment_index)
+    local html
+
+    html = self.cache:get(fragment_index)
+    if html ~= nil then
+        return html
+    end
+
+    -- There has to be a better way to get this..
+
+    local source
+    local fragment_html = self.document:getHTMLFromXPointer("/body/DocFragment[" .. tostring(fragment_index) .. "]")
+    for token in tokenize_html(fragment_html) do
+        if token.type == "tag" and token.text == "docfragment" then
+            source = token.raw:match("Source=\"([^\"]+)\"")
+            break
+        end
+    end
+
+    if source then
+        html = self.document:getDocumentFileContent(source)
+    end
+
+    self.cache:insert(fragment_index, html)
+
+    return html
 end
 
 ---@param cfi string
@@ -607,7 +609,7 @@ function GrimmoryCFIResolver:cfiToXpointer(cfi)
         error("Unable to load fragment HTML for CFI")
     end
 
-    local fragment_path = self:cfiLocalPathToFragmentPath(fragment_html, local_path)
+    local fragment_path = cfi_local_path_to_fragment_path(fragment_html, local_path)
 
     return "/body/DocFragment[" .. tostring(fragment_index) .. "]" .. fragment_path
 end
@@ -638,7 +640,7 @@ function GrimmoryCFIResolver:xpointerToCFI(xpointer)
     end
 
     -- DOM to CFI steps
-    local local_path = self:fragmentPathToCFILocalPath(fragment_html, fragment_path)
+    local local_path = fragment_path_to_cfi_local_path(fragment_html, fragment_path)
 
     logger:dbg("Local path for CFI:", local_path)
 
@@ -650,32 +652,10 @@ end
 ---@param xpointer_end string
 ---@return string cfi
 function GrimmoryCFIResolver:xpointerRangeToCFI(xpointer_start, xpointer_end)
-    -- Decompose XPointer to parts
-    local fragment_start_index, fragment_start_path = decompose_xpointer(xpointer_start)
-    local fragment_end_index, fragment_end_path = decompose_xpointer(xpointer_end)
+    local cfi_start = self:xpointerToCFI(xpointer_start)
+    local cfi_end = self:xpointerToCFI(xpointer_end)
 
-    if fragment_start_index ~= fragment_end_index then
-        logger:err("Unable to convert xpointer range between fragments")
-        error("Unable to handle xpointers between fragments")
-    end
-
-    -- Read HTML for fragment index
-    local fragment_html = self:getFragmentHTML(fragment_start_index)
-
-    if fragment_html == nil then
-        logger:err("Unable to load fragment HTML for XPointer range:", xpointer_start, xpointer_end)
-        error("Unable to load fragment HTML for XPointer")
-    end
-
-    -- DOM to CFI steps
-    local local_start_path = self:fragmentPathToCFILocalPath(fragment_html, fragment_start_path)
-    local local_end_path = self:fragmentPathToCFILocalPath(fragment_html, fragment_end_path)
-
-    -- Get parts that are the same
-    local local_range_path = self:getLocalRangeCFIPath(local_start_path, local_end_path)
-
-    -- Format
-    return format_cfi(fragment_start_index, local_range_path)
+    return self.asCFIRange(cfi_start, cfi_end)
 end
 
 return GrimmoryCFIResolver

--- a/grimmory.koplugin/grimmory/migrations/4_book_event_cfi.sql
+++ b/grimmory.koplugin/grimmory/migrations/4_book_event_cfi.sql
@@ -1,0 +1,1 @@
+ALTER TABLE book_event ADD cfi TEXT NULL;

--- a/grimmory.koplugin/grimmory/reading/recorder.lua
+++ b/grimmory.koplugin/grimmory/reading/recorder.lua
@@ -1,3 +1,4 @@
+local GrimmoryCFIResolver = require("grimmory/cfi_resolver")
 local GrimmoryLogger = require("grimmory/logger")
 
 local logger = GrimmoryLogger:new()
@@ -62,6 +63,29 @@ function ReadingRecorder:getOpenBookXPointer()
     return self.ui.rolling:getLastProgress()
 end
 
+function ReadingRecorder:getOpenBookCFI()
+    if not self.ui or not self.ui.document or self.ui.document.info.has_pages then
+        return nil
+    end
+
+    local xpointer = self.ui.rolling:getLastProgress()
+
+    if xpointer == nil then
+        return nil
+    end
+
+    local cfi_resolver = GrimmoryCFIResolver:new(self.ui.document)
+
+    local ok, cfi = pcall(cfi_resolver.xpointerToCFI, cfi_resolver, xpointer)
+
+    if not ok then
+        logger:err("Could not convert xpointer:", cfi)
+        return nil
+    end
+
+    return cfi
+end
+
 ---@return string | nil book_path current book path
 function ReadingRecorder:getOpenBookPath()
     if not self.ui or not self.ui.document then
@@ -77,8 +101,9 @@ function ReadingRecorder:emitSessionEvent(session_id, event_type)
     local current_page = self:getOpenBookCurrentPage()
     local total_pages = self:getOpenBookTotalPages()
     local xpointer = self:getOpenBookXPointer()
+    local cfi = self:getOpenBookCFI()
 
-    self.repository:insertBookEvent(session_id, event_type, current_page, total_pages, xpointer)
+    self.repository:insertBookEvent(session_id, event_type, current_page, total_pages, xpointer, cfi)
 end
 
 function ReadingRecorder:onSessionStart()

--- a/grimmory.koplugin/grimmory/repository.lua
+++ b/grimmory.koplugin/grimmory/repository.lua
@@ -351,7 +351,8 @@ end
 ---@param current_page number
 ---@param page_count number
 ---@param xpointer string | nil
-function GrimmoryLocalRepository:insertBookEvent(session_id, event_type, current_page, page_count, xpointer)
+---@param cfi string | nil
+function GrimmoryLocalRepository:insertBookEvent(session_id, event_type, current_page, page_count, xpointer, cfi)
     local ok, result = self:withDatabase(
         function(conn)
             local stmt = conn:prepare([[
@@ -362,9 +363,10 @@ function GrimmoryLocalRepository:insertBookEvent(session_id, event_type, current
                         event_type,
                         current_page,
                         page_count,
-                        xpointer
+                        xpointer,
+                        cfi
                     )
-                VALUES (?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
             ]])
 
             stmt:bind(
@@ -373,7 +375,8 @@ function GrimmoryLocalRepository:insertBookEvent(session_id, event_type, current
                 event_type,
                 current_page,
                 page_count,
-                xpointer
+                xpointer,
+                cfi
             )
 
             stmt:step()

--- a/grimmory.koplugin/grimmory/repository.lua
+++ b/grimmory.koplugin/grimmory/repository.lua
@@ -42,6 +42,8 @@ end
 ---@field end_progress number
 ---@field start_xpointer string | nil
 ---@field end_xpointer string | nil
+---@field start_cfi string | nil
+---@field end_cfi string | nil
 
 ---@class ReadingSessionEvent
 ---@field session_id number
@@ -53,6 +55,7 @@ end
 ---@field page number
 ---@field page_count number
 ---@field xpointer string | nil
+---@field cfi string | nil
 
 ---@class ReadingSessionProgress
 ---@field grimmory_id number | nil
@@ -62,6 +65,7 @@ end
 ---@field end_progress number
 ---@field end_page number | nil
 ---@field end_xpointer string | nil
+---@field end_cfi string | nil
 
 ---@class GrimmoryLocalRepository
 ---@field migrations_path string
@@ -407,7 +411,8 @@ function GrimmoryLocalRepository:getReadingProgress(book_id, cutoff)
                     book_event.created_at,
                     book_event.current_page,
                     book_event.page_count,
-                    book_event.xpointer
+                    book_event.xpointer,
+                    book_event.cfi
                 FROM (
                     SELECT
                         s.book_id,
@@ -456,6 +461,7 @@ function GrimmoryLocalRepository:getReadingProgress(book_id, cutoff)
                 end_page = end_page,
                 end_progress = end_progress,
                 end_xpointer = row[7],
+                end_cfi = row[8],
             }
         end
     )
@@ -484,7 +490,8 @@ function GrimmoryLocalRepository:getPendingSessionEvents(book_id)
                     e.created_at,
                     e.current_page,
                     e.page_count,
-                    e.xpointer
+                    e.xpointer,
+                    e.cfi
                 FROM book AS b
                 LEFT JOIN book_sync_status AS bss
                     ON bss.book_id = b.id AND bss.sync_type = "sessions"
@@ -514,6 +521,7 @@ function GrimmoryLocalRepository:getPendingSessionEvents(book_id)
                     page = tonumber(row[7]) or 0,
                     page_count = tonumber(row[8]) or 0,
                     xpointer = row[9],
+                    cfi = row[10],
                 }
 
                 table.insert(results, event)
@@ -590,6 +598,7 @@ function GrimmoryLocalRepository:getPendingSessions(book_id)
                 sessions[#sessions].end_page = event.page
                 sessions[#sessions].end_progress = read_progress
                 sessions[#sessions].end_xpointer = event.xpointer
+                sessions[#sessions].end_cfi = event.cfi
             end
         end
 
@@ -611,6 +620,8 @@ function GrimmoryLocalRepository:getPendingSessions(book_id)
                 end_progress = read_progress,
                 start_xpointer = event.xpointer,
                 end_xpointer = event.xpointer,
+                start_cfi = event.cfi,
+                end_cfi = event.cfi,
             }
 
             table.insert(sessions, new_session)

--- a/spec/grimmory/cfi_resolver_spec.lua
+++ b/spec/grimmory/cfi_resolver_spec.lua
@@ -36,15 +36,6 @@ package.preload["cache"] = function()
 end
 
 local fake_document = stub.new()
-local mock_has_provider = spy.new(function() return true end)
-local mock_open_document = spy.new(function() return fake_document end)
-
-package.preload["document/documentregistry"] = function()
-    return {
-        hasProvider = mock_has_provider,
-        openDocument = mock_open_document,
-    }
-end
 
 local GrimmoryCFIResolver = require("grimmory/cfi_resolver")
 
@@ -80,7 +71,7 @@ describe("GrimmoryCFIResolver", function()
 
     describe("cfiToXpointer", function()
         it("converts simple xpointer", function()
-            local cfi_resolver = GrimmoryCFIResolver:new("example.html")
+            local cfi_resolver = GrimmoryCFIResolver:new(fake_document)
 
             local actual = cfi_resolver:cfiToXpointer(
                 "epubcfi(/6/24!/4/2/4)"
@@ -93,7 +84,7 @@ describe("GrimmoryCFIResolver", function()
         end)
 
         it("converts xpointer referencing second occurrence", function()
-            local cfi_resolver = GrimmoryCFIResolver:new("example.html")
+            local cfi_resolver = GrimmoryCFIResolver:new(fake_document)
 
             local actual = cfi_resolver:cfiToXpointer(
                 "epubcfi(/6/24!/4/2/6)"
@@ -106,7 +97,7 @@ describe("GrimmoryCFIResolver", function()
         end)
 
         it("converts xpointer referencing text", function()
-            local cfi_resolver = GrimmoryCFIResolver:new("example.html")
+            local cfi_resolver = GrimmoryCFIResolver:new(fake_document)
 
             local actual = cfi_resolver:cfiToXpointer(
                 "epubcfi(/6/24!/4/2/4/1:3)"
@@ -119,7 +110,7 @@ describe("GrimmoryCFIResolver", function()
         end)
 
         it("converts xpointer mapping text offsets", function()
-            local cfi_resolver = GrimmoryCFIResolver:new("example.html")
+            local cfi_resolver = GrimmoryCFIResolver:new(fake_document)
 
             local actual = cfi_resolver:cfiToXpointer(
                 "epubcfi(/6/24!/4/2/6/1:19)"
@@ -132,7 +123,7 @@ describe("GrimmoryCFIResolver", function()
         end)
 
         it("converts xpointer referencing text in between elements", function()
-            local cfi_resolver = GrimmoryCFIResolver:new("example.html")
+            local cfi_resolver = GrimmoryCFIResolver:new(fake_document)
 
             local actual = cfi_resolver:cfiToXpointer(
                 "epubcfi(/6/24!/4/2/6/3:3)"
@@ -147,7 +138,7 @@ describe("GrimmoryCFIResolver", function()
 
     describe("xpointerToCFI", function()
         it("converts simple xpointer", function()
-            local cfi_resolver = GrimmoryCFIResolver:new("example.html")
+            local cfi_resolver = GrimmoryCFIResolver:new(fake_document)
 
             local actual = cfi_resolver:xpointerToCFI(
                 "/body/DocFragment[12]/body/div/p"
@@ -160,7 +151,7 @@ describe("GrimmoryCFIResolver", function()
         end)
 
         it("converts xpointer referencing second occurrence", function()
-            local cfi_resolver = GrimmoryCFIResolver:new("example.html")
+            local cfi_resolver = GrimmoryCFIResolver:new(fake_document)
 
             local actual = cfi_resolver:xpointerToCFI(
                 "/body/DocFragment[12]/body/div/p[2]"
@@ -173,7 +164,7 @@ describe("GrimmoryCFIResolver", function()
         end)
 
         it("converts xpointer referencing text", function()
-            local cfi_resolver = GrimmoryCFIResolver:new("example.html")
+            local cfi_resolver = GrimmoryCFIResolver:new(fake_document)
 
             local actual = cfi_resolver:xpointerToCFI(
                 "/body/DocFragment[12]/body/div/p/text().3"
@@ -186,7 +177,7 @@ describe("GrimmoryCFIResolver", function()
         end)
 
         it("converts xpointer mapping text offsets", function()
-            local cfi_resolver = GrimmoryCFIResolver:new("example.html")
+            local cfi_resolver = GrimmoryCFIResolver:new(fake_document)
 
             local actual = cfi_resolver:xpointerToCFI(
                 "/body/DocFragment[12]/body/div/p[2]/text().3"
@@ -199,7 +190,7 @@ describe("GrimmoryCFIResolver", function()
         end)
 
         it("converts xpointer referencing text in between elements", function()
-            local cfi_resolver = GrimmoryCFIResolver:new("example.html")
+            local cfi_resolver = GrimmoryCFIResolver:new(fake_document)
 
             local actual = cfi_resolver:xpointerToCFI(
                 "/body/DocFragment[12]/body/div/p[2]/text()[2].3"
@@ -214,7 +205,7 @@ describe("GrimmoryCFIResolver", function()
 
     describe("xpointerRangeToCFI", function()
         it("supports ranges between two block nodes", function()
-            local cfi_resolver = GrimmoryCFIResolver:new("example.html")
+            local cfi_resolver = GrimmoryCFIResolver:new(fake_document)
 
             local actual = cfi_resolver:xpointerRangeToCFI(
                 "/body/DocFragment[12]/body/div/p",
@@ -228,7 +219,7 @@ describe("GrimmoryCFIResolver", function()
         end)
 
         it("supports ranges between block and inline", function()
-            local cfi_resolver = GrimmoryCFIResolver:new("example.html")
+            local cfi_resolver = GrimmoryCFIResolver:new(fake_document)
 
             local actual = cfi_resolver:xpointerRangeToCFI(
                 "/body/DocFragment[12]/body/div/p/text()[1].2",


### PR DESCRIPTION
ensure that a CFI is recorded with every session event where an xpointer is recorded

this is important because in some cases the book (or iteration of that book) may be gone and we cannot generate a CFI without the content of the book

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reading sessions now track position using CFI (Canonical Fragment Identifier) data for enhanced accuracy and persistence

* **Refactor**
  * Optimized position resolver for improved document instance handling

* **Chores**
  * Updated database schema to support CFI-based position tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->