### PR TITLE
feat: refresh doc_settings after sync

### DIFF
--- a/grimmory.koplugin/main.lua
+++ b/grimmory.koplugin/main.lua
@@ -528,6 +528,16 @@ function Grimmory:onGrimmorySync(verbose, book_path)
         ReadCollection.last_read_time = 0
         ReadCollection:_read()
 
+        if self.ui and self.ui.document and self.ui.doc_settings then
+            local settings = self.doc_metadata:getDocSettings(self.ui.document.file)
+
+            -- Refresh live doc_settings
+            self.ui.doc_settings.data = settings.data
+
+            -- Reload document so any changes apply
+            self.ui:reloadDocument()
+        end
+
         if verbose then
             local message = {
                 _("Completed Grimmory sync")


### PR DESCRIPTION
refreshes the `doc_settings` that's live with data from the sync.  this is needed because the sync writes data to sidecars and cannot interact with the main process' UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sync functionality to refresh and reload the currently open document with updated settings when syncing occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->