### PR TITLE
perf: improve performance of cfi resolver

### DIFF
--- a/grimmory.koplugin/grimmory/cfi_resolver.lua
+++ b/grimmory.koplugin/grimmory/cfi_resolver.lua
@@ -4,6 +4,10 @@ local GrimmoryLogger = require("grimmory/logger")
 
 local logger = GrimmoryLogger:new()
 
+-- The default number of tokens we will bail after
+-- to prevent runaway and performance degradation.
+local DEFAULT_TOKEN_LIMIT = 2500
+
 local HTML_VOID_ELEMENT_TAGS = {
     area=true,
     base=true,
@@ -35,11 +39,21 @@ end
 
 ---@param html string
 ---@return function token_iterator
-local function tokenize_html(html)
+local function tokenize_html(html, token_limit)
+    if token_limit == nil then
+        token_limit = DEFAULT_TOKEN_LIMIT
+    end
+
     local pos = 0
 
     return function ()
         while html ~= nil and pos < #html do
+            token_limit = token_limit - 1
+
+            if token_limit <= 0 then
+                error("Too many tokens")
+            end
+
             local start = find_first(html, {"<!--", "<?", "<"}, pos)
             if not start then
                 local text = html:sub(pos)

--- a/grimmory.koplugin/grimmory/cfi_resolver.lua
+++ b/grimmory.koplugin/grimmory/cfi_resolver.lua
@@ -118,7 +118,7 @@ local function walk_tree(tokens, callback)
 
     -- Search among the siblings
     for token in tokens do
-        if not callback(depth, token) then
+        if depth == 0 and not callback(depth, token) then
             return true
         end
 

--- a/grimmory.koplugin/grimmory/cfi_resolver.lua
+++ b/grimmory.koplugin/grimmory/cfi_resolver.lua
@@ -24,7 +24,7 @@ local HTML_VOID_ELEMENT_TAGS = {
 local function find_first(s, patterns, index)
     local res = {}
     for _, p in ipairs(patterns) do
-        local match = { s:find(p, index) }
+        local match = { s:find(p, index, true) }
         if #match > 0 and (#res == 0 or match[1] < res[1]) then
             res = match
         end
@@ -40,7 +40,7 @@ local function tokenize_html(html)
 
     return function ()
         while html ~= nil and pos < #html do
-            local start = find_first(html, {"<!%-%-", "<[-A-Z0-9a-z/!$]", "<%?"}, pos)
+            local start = find_first(html, {"<!--", "<?", "<"}, pos)
             if not start then
                 local text = html:sub(pos)
                 pos = #html
@@ -68,11 +68,11 @@ local function tokenize_html(html)
 
             local is_ignored = false
 
-            if html:match("^<!%-%-", start) then
-                _,stop = html:find("%-%->", start)
+            if html:sub(start, start + 3) == "<!--" then
+                _,stop = html:find("-->", start, true)
                 is_ignored = true
-            elseif html:match("^<%?", start) then
-                _,stop = html:find("?>", start)
+            elseif html:sub(start, start + 1) == "<?" then
+                _,stop = html:find("?>", start, true)
                 is_ignored = true
             else
                 _,stop = html:find("%b<>", start)

--- a/grimmory.koplugin/grimmory/cfi_resolver.lua
+++ b/grimmory.koplugin/grimmory/cfi_resolver.lua
@@ -628,6 +628,13 @@ end
 function GrimmoryCFIResolver:xpointerToCFI(xpointer)
     logger:dbg("Converting xpointer to CFI:", xpointer)
 
+    xpointer = self.document:getNormalizedXPointer(xpointer)
+
+    if not xpointer then
+        logger:err("XPointer not in document:", xpointer)
+        error("XPointer not in document")
+    end
+
     -- Decompose XPointer to parts
     local fragment_index, fragment_path = decompose_xpointer(xpointer)
 

--- a/grimmory.koplugin/grimmory/cfi_resolver.lua
+++ b/grimmory.koplugin/grimmory/cfi_resolver.lua
@@ -642,12 +642,14 @@ end
 function GrimmoryCFIResolver:xpointerToCFI(xpointer)
     logger:dbg("Converting xpointer to CFI:", xpointer)
 
-    xpointer = self.document:getNormalizedXPointer(xpointer)
+    local normalized_xpointer = self.document:getNormalizedXPointer(xpointer)
 
-    if not xpointer then
+    if not normalized_xpointer then
         logger:err("XPointer not in document:", xpointer)
         error("XPointer not in document")
     end
+
+    xpointer = normalized_xpointer
 
     -- Decompose XPointer to parts
     local fragment_index, fragment_path = decompose_xpointer(xpointer)

--- a/grimmory.koplugin/grimmory/cfi_resolver.lua
+++ b/grimmory.koplugin/grimmory/cfi_resolver.lua
@@ -94,7 +94,7 @@ local function tokenize_html(html)
                 pos = stop + 1
 
                 local found_tag = html:sub(start, stop)
-                local found_end_tag, found_tag_name = found_tag:match("^<(/?)([^%s>]+)")
+                local found_end_tag, found_tag_name = found_tag:match("^<(/?)([^/%s>]+)")
 
                 if found_tag_name then
                     if found_end_tag == "/" then

--- a/grimmory.koplugin/grimmory/reading/recorder.lua
+++ b/grimmory.koplugin/grimmory/reading/recorder.lua
@@ -9,6 +9,7 @@ local logger = GrimmoryLogger:new()
 ---@field last_page integer | nil
 ---@field session_book_path string | nil
 ---@field session_id integer | nil
+---@field cfi_resolver GrimmoryCFIResolver | nil
 local ReadingRecorder = {}
 
 function ReadingRecorder:new(o)
@@ -74,9 +75,11 @@ function ReadingRecorder:getOpenBookCFI()
         return nil
     end
 
-    local cfi_resolver = GrimmoryCFIResolver:new(self.ui.document)
+    if self.cfi_resolver == nil or self.cfi_resolver.document ~= self.ui.document then
+        self.cfi_resolver = GrimmoryCFIResolver:new(self.ui.document)
+    end
 
-    local ok, cfi = pcall(cfi_resolver.xpointerToCFI, cfi_resolver, xpointer)
+    local ok, cfi = pcall(self.cfi_resolver.xpointerToCFI, self.cfi_resolver, xpointer)
 
     if not ok then
         logger:err("Could not convert xpointer:", cfi)

--- a/grimmory.koplugin/grimmory/reading/recorder.lua
+++ b/grimmory.koplugin/grimmory/reading/recorder.lua
@@ -182,6 +182,7 @@ function ReadingRecorder:onSessionEnd()
     self.last_page = nil
     self.session_id = nil
     self.session_book_path = nil
+    self.cfi_resolver = nil
 end
 
 return ReadingRecorder

--- a/spec/grimmory/cfi_resolver_spec.lua
+++ b/spec/grimmory/cfi_resolver_spec.lua
@@ -60,6 +60,7 @@ local EXAMPLE_HTML = [[CDATA
 describe("GrimmoryCFIResolver", function()
     before_each(function()
         fake_document.loadDocument = spy.new(function() return true end)
+        fake_document.getNormalizedXPointer = spy.new(function(_, xp) return xp end)
         fake_document.getHTMLFromXPointer = spy.new(function() return "<DocFragment Source=\"example.html\">" end)
         fake_document.getDocumentFileContent = spy.new(function() return EXAMPLE_HTML end)
         fake_document.close = spy.new(function() end)


### PR DESCRIPTION
improves the performance of the CFI resolver by:

* simplifying the open-token search
* end-token detection
* ignoring sub-children tokens
* limiting to the number of tokens that may be searched through
* caching the CFI resolver on page recording when the document does not change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved HTML parsing reliability by enforcing a configurable maximum token count to prevent runaway processing.
  * Enhanced bookmark/CFI conversion accuracy by normalizing XPointer inputs and failing safely when normalization fails.

* **Performance**
  * Improved session efficiency by caching and reusing the CFI resolver during reading sessions, reducing repeated initialization work.  

* **Tests**
  * Updated resolver specs to mock XPointer normalization behavior for consistent test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->