### PR TITLE
fix: string quotes in SQL JOIN conditions

### DIFF
--- a/grimmory.koplugin/grimmory/repository.lua
+++ b/grimmory.koplugin/grimmory/repository.lua
@@ -494,7 +494,7 @@ function GrimmoryLocalRepository:getPendingSessionEvents(book_id)
                     e.cfi
                 FROM book AS b
                 LEFT JOIN book_sync_status AS bss
-                    ON bss.book_id = b.id AND bss.sync_type = "sessions"
+                    ON bss.book_id = b.id AND bss.sync_type = 'sessions'
                 JOIN book_session AS s ON s.book_id = b.id
                 JOIN book_event AS e ON e.session_id = s.id
                 WHERE
@@ -697,9 +697,9 @@ function GrimmoryLocalRepository:getBooksPendingSync(
                 JOIN book_session ON book.id = book_session.book_id
                 JOIN book_event ON book_session.id = book_event.session_id
                 LEFT JOIN book_sync_status AS sync_sessions
-                    ON book.id = sync_sessions.book_id AND sync_sessions.sync_type = "sessions"
+                    ON book.id = sync_sessions.book_id AND sync_sessions.sync_type = 'sessions'
                 LEFT JOIN book_sync_status AS sync_progress
-                    ON book.id = sync_progress.book_id AND sync_progress.sync_type = "progress"
+                    ON book.id = sync_progress.book_id AND sync_progress.sync_type = 'progress'
                 WHERE
                     grimmory_id IS NOT NULL
                     AND


### PR DESCRIPTION
Fixes SQL syntax in repository.lua where string literals within LEFT JOIN conditions were incorrectly enclosed in double quotes ("). This caused the SQLite engine to interpret them as column identifiers, leading to runtime failures.

**Problem**

When triggering metadata synchronization (pushAllPendingBookMetadata), the ljsqlite3 driver threw the following exception in crash.log:
`
ljsqlite3[error] no such column: "sessions" - should this be a string literal in single-quotes?`

This error broke the logical execution of getBooksPendingSync, preventing pending books from being tracked and pushed to the server.

**Solution**

Replaced double quotes with single quotes ('sessions' and 'progress') within the query's ON clauses, conforming to standard SQLite behavior for text literals.

**Impact**

Restores the initial synchronization flow of the plugin. Eliminates exceptions and overhead caused by the KOReader local database.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected database query formatting for improved data synchronization consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->