### PR TITLE
fix: properly wait for automatic wifi without breaking executor

### DIFF
--- a/grimmory.koplugin/grimmory/wifi_manager.lua
+++ b/grimmory.koplugin/grimmory/wifi_manager.lua
@@ -41,12 +41,12 @@ function WifiManager:withWifi(callback)
   local original_on = NetworkManager.wifi_was_on
   local calling_coroutine = coroutine.running()
 
-  NetworkManager:turnOnWifiAndWaitForConnection(function()
+  NetworkManager:runWhenConnected(function()
     -- restore original "was on" state to prevent wifi
     -- being restored automatically after suspend
     NetworkManager.wifi_was_on = original_on
     self.connection_pending = false
-
+    
     if calling_coroutine and coroutine.status(calling_coroutine) == "suspended" then
       -- resume back into the original coroutine so `callback`
       -- (and anything it calls, like GrimmoryExecutor:run)
@@ -55,18 +55,14 @@ function WifiManager:withWifi(callback)
       if not ok then
           logger:err("Error resuming coroutine after wifi connect:", err)
       end
-    else
-      -- fallback: just call directly, accepting the executor
-      -- check may fail
-      callback(false)
-    end
-    NetworkManager:turnOffWifi()
   end)
 
   local resumed_callback = coroutine.yield()
   if resumed_callback then
       resumed_callback(false)
   end
+  
+  NetworkManager:turnOffWifi()
 end
 
 return WifiManager

--- a/grimmory.koplugin/grimmory/wifi_manager.lua
+++ b/grimmory.koplugin/grimmory/wifi_manager.lua
@@ -33,7 +33,10 @@ function WifiManager:withWifi(callback)
     return
   end
 
-  if not Device:hasWifiRestore() then
+  logger:err(Device:hasWifiToggle())
+  logger:err(Device:hasWifiRestore())
+
+  if not Device:hasWifiToggle() then
     logger:err("Requested with wifi but cannot enable")
     return
   end

--- a/grimmory.koplugin/grimmory/wifi_manager.lua
+++ b/grimmory.koplugin/grimmory/wifi_manager.lua
@@ -41,7 +41,7 @@ function WifiManager:withWifi(callback)
   local original_on = NetworkManager.wifi_was_on
   local calling_coroutine = coroutine.running()
 
-  NetworkManager:runWhenConnected(function()
+  NetworkManager:turnOnWifiAndWaitForConnection(function()
     -- restore original "was on" state to prevent wifi
     -- being restored automatically after suspend
     NetworkManager.wifi_was_on = original_on

--- a/grimmory.koplugin/grimmory/wifi_manager.lua
+++ b/grimmory.koplugin/grimmory/wifi_manager.lua
@@ -33,9 +33,6 @@ function WifiManager:withWifi(callback)
     return
   end
 
-  logger:err(Device:hasWifiToggle())
-  logger:err(Device:hasWifiRestore())
-
   if not Device:hasWifiToggle() then
     logger:err("Requested with wifi but cannot enable")
     return

--- a/grimmory.koplugin/grimmory/wifi_manager.lua
+++ b/grimmory.koplugin/grimmory/wifi_manager.lua
@@ -46,7 +46,6 @@ function WifiManager:withWifi(callback)
     -- being restored automatically after suspend
     NetworkManager.wifi_was_on = original_on
     self.connection_pending = false
-    
     if calling_coroutine and coroutine.status(calling_coroutine) == "suspended" then
       -- resume back into the original coroutine so `callback`
       -- (and anything it calls, like GrimmoryExecutor:run)

--- a/grimmory.koplugin/grimmory/wifi_manager.lua
+++ b/grimmory.koplugin/grimmory/wifi_manager.lua
@@ -55,13 +55,14 @@ function WifiManager:withWifi(callback)
       if not ok then
           logger:err("Error resuming coroutine after wifi connect:", err)
       end
+    end
   end)
 
   local resumed_callback = coroutine.yield()
   if resumed_callback then
       resumed_callback(false)
   end
-  
+
   NetworkManager:turnOffWifi()
 end
 

--- a/grimmory.koplugin/grimmory/wifi_manager.lua
+++ b/grimmory.koplugin/grimmory/wifi_manager.lua
@@ -39,18 +39,34 @@ function WifiManager:withWifi(callback)
   end
 
   local original_on = NetworkManager.wifi_was_on
+  local calling_coroutine = coroutine.running()
 
   NetworkManager:turnOnWifiAndWaitForConnection(function()
     -- restore original "was on" state to prevent wifi
     -- being restored automatically after suspend
     NetworkManager.wifi_was_on = original_on
-
     self.connection_pending = false
 
-    callback(true)
-
+    if calling_coroutine and coroutine.status(calling_coroutine) == "suspended" then
+      -- resume back into the original coroutine so `callback`
+      -- (and anything it calls, like GrimmoryExecutor:run)
+      -- executes with the correct coroutine context
+      local ok, err = coroutine.resume(calling_coroutine, callback)
+      if not ok then
+          logger:err("Error resuming coroutine after wifi connect:", err)
+      end
+    else
+      -- fallback: just call directly, accepting the executor
+      -- check may fail
+      callback(false)
+    end
     NetworkManager:turnOffWifi()
   end)
+
+  local resumed_callback = coroutine.yield()
+  if resumed_callback then
+      resumed_callback(false)
+  end
 end
 
 return WifiManager


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WiFi enablement by using the correct device capability check for restoring/toggling WiFi.
  * Updated the WiFi connect flow to coordinate asynchronous connection events more reliably, so callbacks reflect the real connection result and WiFi isn’t turned off prematurely.

* **Refactor**
  * Streamlined the WiFi enable/wait workflow to use coroutine-based coordination for cleaner completion handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->