### PR TITLE
fix: proper toggle of `syncReadingSessions()`

### DIFF
--- a/grimmory.koplugin/grimmory/settings.lua
+++ b/grimmory.koplugin/grimmory/settings.lua
@@ -270,7 +270,7 @@ function GrimmorySettings:getSyncReadingSessions()
 end
 
 function GrimmorySettings:toggleSyncReadingSessions()
-    self.data.sync_reading_sessions = not self.data.sync_reading_sessions
+    self.data.sync_reading_sessions = not self:getSyncReadingSessions()
     self:write()
 end
 


### PR DESCRIPTION
the sync reading session toggle wasn't being appropriately toggled