### PR TITLE
refactor: drop unused fields from sync

### DIFF
--- a/grimmory.koplugin/grimmory/synchronize.lua
+++ b/grimmory.koplugin/grimmory/synchronize.lua
@@ -12,11 +12,7 @@ local logger = GrimmoryLogger:new()
 ---@field settings GrimmorySettings
 ---@field api GrimmoryAPI
 ---@field doc_metadata GrimmoryDocMetadata
----@field cached_books Book[]
-local GrimmorySynchronize = {
-    synchronize_sessions_since = 0,
-    cached_books = {},
-}
+local GrimmorySynchronize = {}
 
 function GrimmorySynchronize:new(o)
     o = o or {}


### PR DESCRIPTION
the sync class had unused fields from an older iteration