### PR TITLE
fix: only send progress when needed

### DIFF
--- a/grimmory.koplugin/grimmory/repository.lua
+++ b/grimmory.koplugin/grimmory/repository.lua
@@ -710,7 +710,43 @@ function GrimmoryLocalRepository:updateBookSyncTimestamp(book_id, sync_type, tim
     end
 
     return true
+end
 
+---@param book_id number
+---@param sync_type RepositorySyncType
+---@return boolean ok
+---@return integer timestamp
+function GrimmoryLocalRepository:getBookSyncTimestamp(book_id, sync_type)
+    local ok, timestamp = self:withDatabase(
+        function(conn)
+            local stmt = conn:prepare([[
+                SELECT
+                    last_synced_at
+                FROM book_sync_status
+                WHERE
+                    book_id = ?
+                    AND
+                    sync_type = ?
+            ]])
+
+            stmt:bind(book_id, sync_type)
+            local row = stmt:step()
+            stmt:close()
+
+            if row == nil then
+                return 0
+            end
+
+            return tonumber(row[1]) or 0
+        end
+    )
+
+    if not ok then
+        logger:err("Failed to get book sync status:", book_id, "-", timestamp)
+        return false, nil
+    end
+
+    return true, timestamp
 end
 
 ---@param with_sessions boolean

--- a/grimmory.koplugin/grimmory/synchronize.lua
+++ b/grimmory.koplugin/grimmory/synchronize.lua
@@ -31,25 +31,40 @@ function GrimmorySynchronize:pushBookProgress(book_id, callback)
 
     local progress_ok, progress = self.repository:getReadingProgress(book_id)
 
-    if progress_ok and progress ~= nil then
-        logger:info("Synchronizing reading progress for:", book_id)
-        local ok = self.reading_progress_manager:pushRemoteProgress(progress)
+    if not progress_ok or progress == nil then
+        logger:dbg("No local reading progress for book:", book_id)
+        return
+    end
 
-        if ok then
-            callback({
-                state = "progress-pushed",
-                book_path = progress.book_path,
-                book_md5 = progress.book_md5,
-            })
+    local sync_status_ok, last_synced_at = self.repository:getBookSyncTimestamp(book_id, "progress")
 
-            self.repository:updateBookSyncTimestamp(book_id, "progress", progress.end_time)
-        else
-            callback({
-                state = "progress-failed",
-                book_path = progress.book_path,
-                book_md5 = progress.book_md5,
-            })
-        end
+    if not sync_status_ok then
+        logger:err("Unable to get sync status for book, not blindly syncing:", book_id)
+        return
+    end
+
+    if last_synced_at ~= nil and last_synced_at >= progress.end_time then
+        logger:dbg("Book progress already synced, skipping:", book_id, "-", last_synced_at)
+        return
+    end
+
+    logger:info("Synchronizing reading progress for:", book_id, ";", last_synced_at, "->", progress.end_time)
+    local ok = self.reading_progress_manager:pushRemoteProgress(progress)
+
+    if ok then
+        callback({
+            state = "progress-pushed",
+            book_path = progress.book_path,
+            book_md5 = progress.book_md5,
+        })
+
+        self.repository:updateBookSyncTimestamp(book_id, "progress", progress.end_time)
+    else
+        callback({
+            state = "progress-failed",
+            book_path = progress.book_path,
+            book_md5 = progress.book_md5,
+        })
     end
 end
 
@@ -80,6 +95,7 @@ function GrimmorySynchronize:pushBookSessions(book_id, callback)
                 bookPath = session.book_path,
                 since = session.end_time,
             })
+
         elseif total_pages < threshold_pages then
             logger:info("Skipped session below page threshold for book", book_id)
             callback({
@@ -87,6 +103,7 @@ function GrimmorySynchronize:pushBookSessions(book_id, callback)
                 bookPath = session.book_path,
                 since = session.end_time,
             })
+
         elseif session.grimmory_id == nil then
             logger:err("Session failed recording with error for book: ", book_id, " - ", "No Grimmory ID")
             callback({


### PR DESCRIPTION
updates the progress sync to only send progress when the local progress hasn't been sent yet.  this uses the sync status for determining when new data is available to push to the remote grimmory server, preventing us getting stuck in situations - in particular, when the last session attached to a book is too short to send

fixes #143

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reading progress sync so books with recoverable progress data are more likely to sync successfully.
  * Fixed timestamp handling for synced books, helping the app better detect whether progress is already up to date.
  * Kept session syncing behavior consistent while preserving the existing page-threshold skip rule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->