### PR TITLE
fix: properly split CFI when creating xpointer range

### DIFF
--- a/grimmory.koplugin/grimmory/cfi_resolver.lua
+++ b/grimmory.koplugin/grimmory/cfi_resolver.lua
@@ -409,13 +409,13 @@ end
 ---@return string cfi_start
 ---@return string cfi_end
 local function split_local_range_cfi_path(cfi)
-    local root, path_a, path_b = cfi:match("^([^,]+),([^,]+),([^,]+)$")
+    local root, path_a, path_b = cfi:match("epubcfi%(([^,%)]+),([^,%)]+),([^,%)]+)%)$")
 
     if root == nil or path_a == nil or path_b == nil then
         error("invalid CFI range")
     end
 
-    return root .. path_a, root .. path_b
+    return "epubcfi(" .. root .. path_a .. ")", "epubcfi(" .. root .. path_b .. ")"
 end
 
 ---@param fragment_html any

--- a/spec/grimmory/cfi_resolver_spec.lua
+++ b/spec/grimmory/cfi_resolver_spec.lua
@@ -252,6 +252,19 @@ describe("GrimmoryCFIResolver", function()
         end)
     end)
 
+    describe("cfiRangeToXPointers", function()
+        it("handles start and end within text blocks", function()
+            local cfi_resolver = GrimmoryCFIResolver:new(fake_document)
+
+            local actual_start, actual_end = cfi_resolver:cfiRangeToXPointers(
+                "epubcfi(/6/24!/4/2/6,/3:3,/3:5)"
+            )
+
+            assert.are.equal("/body/DocFragment[12]/body/div/p[2]/text()[2].3", actual_start)
+            assert.are.equal("/body/DocFragment[12]/body/div/p[2]/text()[2].5", actual_end)
+        end)
+    end)
+
     describe("xpointerRangeToCFI", function()
         it("supports ranges between two block nodes", function()
             local cfi_resolver = GrimmoryCFIResolver:new(fake_document)


### PR DESCRIPTION
without this, the CFI to xpointer range would drop the initial text offset

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of CFI range parsing so start and end positions are converted more reliably.
  * Fixed xpointer output for ranges within the same text block, ensuring offsets are mapped correctly.

* **Tests**
  * Added coverage for CFI range-to-xpointer conversion to verify expected start and end results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->