### PR TITLE
feat: add session events for annotations

### DIFF
--- a/grimmory.koplugin/grimmory/reading/recorder.lua
+++ b/grimmory.koplugin/grimmory/reading/recorder.lua
@@ -150,6 +150,18 @@ function ReadingRecorder:onSessionStart()
     self:emitSessionEvent(self.session_id, "session-start")
 end
 
+function ReadingRecorder:onAnnotationAdded()
+    self:emitSessionEvent(self.session_id, "annotation-added")
+end
+
+function ReadingRecorder:onAnnotationRemoved()
+    self:emitSessionEvent(self.session_id, "annotation-removed")
+end
+
+function ReadingRecorder:onAnnotationUpdated()
+    self:emitSessionEvent(self.session_id, "annotation-updated")
+end
+
 function ReadingRecorder:onPageUpdate()
     -- If the session is active and the book path has changed we
     -- somehow missed the end session event

--- a/grimmory.koplugin/grimmory/repository.lua
+++ b/grimmory.koplugin/grimmory/repository.lua
@@ -28,6 +28,9 @@ end
 ---| "page"
 ---| "session-start"
 ---| "session-end"
+---| "annotation-added"
+---| "annotation-removed"
+---| "annotation-updated"
 
 ---@class ReadingSession
 ---@field grimmory_id number | nil

--- a/grimmory.koplugin/main.lua
+++ b/grimmory.koplugin/main.lua
@@ -251,6 +251,20 @@ function Grimmory:onCloseDocument()
     end
 end
 
+function Grimmory:onAnnotationsModified(annotation_info)
+    logger:dbg("Annotations modified", annotation_info)
+
+    -- annotation is at annotation_info[1]
+
+    if annotation_info.index_modified == nil then
+        self.reading_recorder:onAnnotationUpdated()
+    elseif annotation_info.index_modified < 0 then
+        self.reading_recorder:onAnnotationRemoved()
+    else
+        self.reading_recorder:onAnnotationAdded()
+    end
+end
+
 function Grimmory:onGrimmorySettingsChanged()
     logger:dbg("Settings Changed")
 


### PR DESCRIPTION
this adds events in the session tracking for when annotations are changed - which can be used in the future for annotation sync

related to #65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for annotation activity updates, including added, removed, and modified events.
  * Improved handling so changes to annotations are now tracked and recorded during reading sessions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->