### PR TITLE
refactor: move UI refresh helper into doc_metadata

### DIFF
--- a/grimmory.koplugin/grimmory/doc_metadata.lua
+++ b/grimmory.koplugin/grimmory/doc_metadata.lua
@@ -6,6 +6,14 @@ local util = require("util")
 local GrimmoryLogger = require("grimmory/logger")
 local logger = GrimmoryLogger:new()
 
+local function is_path_open(ui, path)
+    if ui.document == nil or ui.document.file == nil then
+        return false
+    end
+
+    return ui.document.file == path
+end
+
 ---@class GrimmoryDocMetadata
 ---@field private props_cache any
 ---@field private ui any
@@ -231,7 +239,10 @@ function DocMetadata:setProgress(path, percent, xpointer, page)
     end
 
     settings:flush()
-    self:refreshUI()
+
+    if is_path_open(self.ui, path) then
+        self:refreshUI()
+    end
 end
 
 return DocMetadata

--- a/grimmory.koplugin/grimmory/doc_metadata.lua
+++ b/grimmory.koplugin/grimmory/doc_metadata.lua
@@ -231,6 +231,7 @@ function DocMetadata:setProgress(path, percent, xpointer, page)
     end
 
     settings:flush()
+    self:refreshUI()
 end
 
 return DocMetadata

--- a/grimmory.koplugin/grimmory/doc_metadata.lua
+++ b/grimmory.koplugin/grimmory/doc_metadata.lua
@@ -8,10 +8,11 @@ local logger = GrimmoryLogger:new()
 
 ---@class GrimmoryDocMetadata
 ---@field private props_cache any
+---@field private ui any
 local DocMetadata = {}
 
-function DocMetadata:new()
-    local o = {}
+function DocMetadata:new(o)
+    o = o or {}
     setmetatable(o, self)
     self.__index = self
     o:init()
@@ -20,6 +21,32 @@ end
 
 function DocMetadata:init()
     self.props_cache = Cache:new({ slots = 1024 })
+end
+
+function DocMetadata:refreshUI()
+    if self.ui == nil then
+        logger:dbg("Cannot refresh UI")
+        return
+    end
+
+    if self.ui.document == nil or self.ui.document.file == nil then
+        logger:dbg("No file is open, cannot refresh")
+        return
+    end
+
+    local settings = self:getDocSettings(self.ui.document.file)
+
+    -- Refresh live doc_settings
+    self.ui.doc_settings.data = settings.data
+
+    if self.ui.annotation then
+        -- Refresh annotations for any open document
+        self.ui.annotation.annotations = settings:readSetting("annotations")
+        pcall(self.ui.annotation.updateAnnotations, self.ui.annotation, true, true)
+    end
+
+    -- Reload document so any changes apply
+    self.ui:reloadDocument()
 end
 
 function DocMetadata:purge(path)

--- a/grimmory.koplugin/main.lua
+++ b/grimmory.koplugin/main.lua
@@ -85,7 +85,9 @@ function Grimmory:init()
         settings = self.settings,
     })
 
-    self.doc_metadata = GrimmoryDocMetadata:new()
+    self.doc_metadata = GrimmoryDocMetadata:new({
+        ui = self.ui,
+    })
 
     self.reading_recorder = GrimmoryReadingRecorder:new({
         repository = self.repository,
@@ -557,15 +559,7 @@ function Grimmory:onGrimmorySync(verbose, book_path, refresh_book)
         ReadCollection.last_read_time = 0
         ReadCollection:_read()
 
-        if self.ui and self.ui.document and self.ui.doc_settings then
-            local settings = self.doc_metadata:getDocSettings(self.ui.document.file)
-
-            -- Refresh live doc_settings
-            self.ui.doc_settings.data = settings.data
-
-            -- Reload document so any changes apply
-            self.ui:reloadDocument()
-        end
+        self.doc_metadata:refreshUI()
 
         if verbose then
             local message = {


### PR DESCRIPTION
when metadata is updated, the data needs to be both flushed and any "live" versions of the metadata need to be refreshed - such as in the UI.  this had been done with a helper on sync but there are other cases where this is needed or we lose data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved syncing so document progress and related updates refresh the on-screen content more reliably.
  * Updated the app to reload the current document after progress changes, helping keep displayed information in sync.
  * Fixed annotation refresh behavior during updates, reducing the chance of stale or outdated content appearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->