### PR TITLE
fix: move refresh UI to only when required

### DIFF
--- a/grimmory.koplugin/grimmory/doc_metadata.lua
+++ b/grimmory.koplugin/grimmory/doc_metadata.lua
@@ -6,14 +6,6 @@ local util = require("util")
 local GrimmoryLogger = require("grimmory/logger")
 local logger = GrimmoryLogger:new()
 
-local function is_path_open(ui, path)
-    if ui.document == nil or ui.document.file == nil then
-        return false
-    end
-
-    return ui.document.file == path
-end
-
 ---@class GrimmoryDocMetadata
 ---@field private props_cache any
 ---@field private ui any
@@ -31,32 +23,6 @@ function DocMetadata:init()
     self.props_cache = Cache:new({ slots = 1024 })
 end
 
-function DocMetadata:refreshUI()
-    if self.ui == nil then
-        logger:dbg("Cannot refresh UI")
-        return
-    end
-
-    if self.ui.document == nil or self.ui.document.file == nil then
-        logger:dbg("No file is open, cannot refresh")
-        return
-    end
-
-    local settings = self:getDocSettings(self.ui.document.file)
-
-    -- Refresh live doc_settings
-    self.ui.doc_settings.data = settings.data
-
-    if self.ui.annotation then
-        -- Refresh annotations for any open document
-        self.ui.annotation.annotations = settings:readSetting("annotations")
-        pcall(self.ui.annotation.updateAnnotations, self.ui.annotation, true, true)
-    end
-
-    -- Reload document so any changes apply
-    self.ui:reloadDocument()
-end
-
 function DocMetadata:purge(path)
     local settings = self:getDocSettings(path)
 
@@ -65,10 +31,20 @@ function DocMetadata:purge(path)
     end
 end
 
-function DocMetadata:getDocSettings(path)
-    local settings = DocSettings:open(path)
+function DocMetadata:getDocSettings(path, fresh)
+    if self.ui and self.ui.document ~= nil and self.ui.document.file ~= nil then
+        if self.ui.document.file == path and self.ui.doc_settings then
+            if fresh then
+                local settings = DocSettings:open(path)
 
-    return settings
+                self.ui.doc_settings.data = settings.data
+            end
+
+            return self.ui.doc_settings
+        end
+    end
+
+    return DocSettings:open(path)
 end
 
 function DocMetadata:getDocProps(path)
@@ -239,10 +215,6 @@ function DocMetadata:setProgress(path, percent, xpointer, page)
     end
 
     settings:flush()
-
-    if is_path_open(self.ui, path) then
-        self:refreshUI()
-    end
 end
 
 return DocMetadata

--- a/grimmory.koplugin/main.lua
+++ b/grimmory.koplugin/main.lua
@@ -316,6 +316,9 @@ function Grimmory:pullProgressForOpenBook()
 
     local book_path = self.ui.document.file
 
+    -- Tell everything to flush so we have data available for our sync
+    UIManager:broadcastEvent(Event:new("FlushSettings"))
+
     self.executor:background(
         function(run)
             local ok, latest_progress = run(
@@ -387,6 +390,28 @@ function Grimmory:onGrimmorySyncOpenBook(verbose)
     local book_path = self.ui.document.file
 
     return self:onGrimmorySync(verbose, book_path)
+end
+
+function Grimmory:refreshUI()
+   if self.ui == nil then
+        return
+    end
+
+    if self.ui.document == nil or self.ui.document.file == nil then
+        logger:dbg("No file is open, cannot refresh")
+        return
+    end
+
+    local settings = self.doc_metadata:getDocSettings(self.ui.document.file, true)
+
+    if self.ui.annotation then
+        -- Refresh annotations for any open document
+        self.ui.annotation.annotations = settings:readSetting("annotations")
+        pcall(self.ui.annotation.updateAnnotations, self.ui.annotation, true, true)
+    end
+
+    -- Reload document so any changes apply
+    self.ui:reloadDocument()
 end
 
 function Grimmory:onGrimmorySync(verbose, book_path, refresh_book)
@@ -559,7 +584,7 @@ function Grimmory:onGrimmorySync(verbose, book_path, refresh_book)
         ReadCollection.last_read_time = 0
         ReadCollection:_read()
 
-        self.doc_metadata:refreshUI()
+        self:refreshUI()
 
         if verbose then
             local message = {


### PR DESCRIPTION
running the reload document on some events basically breaks the UI entirely, so instead try to use the UIs doc settings when possible and otherwise read -- then only after sync run the full refresh UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sync progress now refreshes the currently open book more completely after updates.

* **Bug Fixes**
  * Improved live document updates so reading progress, annotations, and book display stay in sync after a refresh.
  * Reduced unnecessary re-opening of document settings when the same book is already open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->