### PR TITLE
fix: use `step` rather than `exec` when executing statement

### DIFF
--- a/grimmory.koplugin/grimmory/repository.lua
+++ b/grimmory.koplugin/grimmory/repository.lua
@@ -246,7 +246,7 @@ function GrimmoryLocalRepository:updateBook(book_id, partial_md5)
 
             stmt:bind(partial_md5, book_id)
 
-            stmt:exec()
+            stmt:step()
             stmt:close()
         end,
         "rw"


### PR DESCRIPTION
the update uses `exec` which is not a function for this sqlite library and I keep reading the wrong docs and using the wrong functions