### PR TITLE
chore: prevent wifi toggle when no wifi

### DIFF
--- a/grimmory.koplugin/grimmory/ui/menu.lua
+++ b/grimmory.koplugin/grimmory/ui/menu.lua
@@ -1,6 +1,7 @@
 local _ = require("gettext")
 local T = require("ffi/util").template
 
+local Device = require("device")
 local Event = require("ui/event")
 local ConfirmBox = require("ui/widget/confirmbox")
 local UIManager = require("ui/uimanager")
@@ -131,6 +132,7 @@ function GrimmoryMenu:getAutomaticSyncOptionsMenu()
         },
         {
             text = _("Enable WiFi"),
+            enabled = Device:hasWifiToggle(),
             checked_func = function()
                 return self.settings:getSyncEnableWifi()
             end,


### PR DESCRIPTION
this turns off the `Enable WiFi` toggle when there is no wifi

fixes #153 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The automatic sync menu now shows the “Enable WiFi” option only on devices that support a Wi‑Fi toggle, reducing confusion on unsupported devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->