### PR TITLE
feat: end session when adopting progress

### DIFF
--- a/grimmory.koplugin/grimmory/reading/progress_manager.lua
+++ b/grimmory.koplugin/grimmory/reading/progress_manager.lua
@@ -42,6 +42,7 @@ end
 ---@field api GrimmoryAPI
 ---@field repository GrimmoryLocalRepository
 ---@field settings GrimmorySettings
+---@field reading_recorder ReadingRecorder
 ---@field private koreader_auth_id string | nil
 ---@field private koreader_auth_secret_md5 string | nil
 local ReadingProgressManager = {}
@@ -229,6 +230,8 @@ function ReadingProgressManager:applyProgress(progress)
     -- If book path is the currently open book, use the go to command
     -- DocMetadata -> "last_xpointer" to progress
     if self.ui.document and progress.book_path == self.ui.document.file then
+        self.reading_recorder:onSessionEnd()
+
         if self.ui.document.info.has_pages then
             if progress.end_page then
                 self.ui:handleEvent(Event:new("GotoPage", tonumber(progress.end_page)))

--- a/grimmory.koplugin/main.lua
+++ b/grimmory.koplugin/main.lua
@@ -113,6 +113,7 @@ function Grimmory:init()
         api = self.api,
         settings = self.settings,
         repository = self.repository,
+        reading_recorder = self.reading_recorder,
     })
 
     self.dialog_manager = GrimmoryDialogManager:new({


### PR DESCRIPTION
fixes #117

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reading progress now properly closes the current reading session before restoring or saving progress, helping keep reading state in sync.
  * Improved handling of reading progress so the app can better resume your place in the current book.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->