### PR TITLE
fix: show new cover when individual book is reloaded

### DIFF
--- a/grimmory.koplugin/main.lua
+++ b/grimmory.koplugin/main.lua
@@ -600,8 +600,6 @@ function Grimmory:onGrimmorySync(verbose, book_path, refresh_book)
         ReadCollection.last_read_time = 0
         ReadCollection:_read()
 
-        self:refreshUI()
-
         if book_path ~= nil then
             logger:info("Invalidating cache for book:", book_path)
 
@@ -612,6 +610,8 @@ function Grimmory:onGrimmorySync(verbose, book_path, refresh_book)
                 self.ui.file_chooser:init()
             end
         end
+
+        self:refreshUI()
 
         if verbose then
             local message = {

--- a/grimmory.koplugin/main.lua
+++ b/grimmory.koplugin/main.lua
@@ -602,6 +602,17 @@ function Grimmory:onGrimmorySync(verbose, book_path, refresh_book)
 
         self:refreshUI()
 
+        if book_path ~= nil then
+            logger:info("Invalidating cache for book:", book_path)
+
+            UIManager:broadcastEvent(Event:new("InvalidateMetadataCache", book_path))
+
+            if self.ui and self.ui.file_chooser then
+                self.ui.file_chooser.resetBookInfoCache(book_path)
+                self.ui.file_chooser:init()
+            end
+        end
+
         if verbose then
             local message = {
                 _("Completed Grimmory sync")


### PR DESCRIPTION
after a file is reloaded from Grimmory, we need to refresh the cache so the new cover / metadata applies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved post-sync behavior by invalidating the affected book’s metadata cache before updating the UI.
  * Ensures the file chooser no longer shows stale book details after syncing a specific book.
  * Keeps displayed book information consistent with the latest synced metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->