### PR TITLE
fix: handle CFI for nodes that have no space between them

### DIFF
--- a/grimmory.koplugin/grimmory/cfi_resolver.lua
+++ b/grimmory.koplugin/grimmory/cfi_resolver.lua
@@ -46,6 +46,11 @@ local function tokenize_html(html, token_limit)
 
     local pos = 0
 
+    -- Flag to ensure text always is generated between nodes
+    -- for proper counters.  The DOM must be tag -> text -> tag -> text,
+    -- always or the counts get incorrect.
+    local has_seen_text = false
+
     return function ()
         while html ~= nil and pos < #html do
             token_limit = token_limit - 1
@@ -66,10 +71,11 @@ local function tokenize_html(html, token_limit)
                 }
             end
 
-            if start ~= pos then
+            if not has_seen_text or start ~= pos then
                 local text = html:sub(pos, start - 1)
 
                 pos = start
+                has_seen_text = true
 
                 return {
                     type = "text",
@@ -106,6 +112,8 @@ local function tokenize_html(html, token_limit)
                 pos = stop + 1
             else
                 pos = stop + 1
+
+                has_seen_text = false
 
                 local found_tag = html:sub(start, stop)
                 local found_end_tag, found_tag_name = found_tag:match("^<(/?)([^/%s>]+)")

--- a/spec/grimmory/cfi_resolver_spec.lua
+++ b/spec/grimmory/cfi_resolver_spec.lua
@@ -52,6 +52,10 @@ local EXAMPLE_HTML = [[CDATA
                 with
                 <bold>more</bold> text.
             </p>
+            <p class="foo"><span class="foo">
+                <img />
+                </span>Third <span>paragraph with</span> <bold>lots</bold> of <span>inline</span> elements.
+            </p>
         </div>
     </body>
 </html>
@@ -183,6 +187,19 @@ describe("GrimmoryCFIResolver", function()
                 actual
             )
         end)
+
+        it("converts to xpointer referencing a target with no spaces between nodes", function()
+            local cfi_resolver = GrimmoryCFIResolver:new(fake_document)
+
+            local actual = cfi_resolver:cfiToXpointer(
+                "epubcfi(/6/24!/4/2/8/4/1:1)"
+            )
+
+            assert.are.equal(
+            "/body/DocFragment[12]/body/div/p[3]/span[2]/text().1",
+                actual
+            )
+        end)
     end)
 
     describe("xpointerToCFI", function()
@@ -247,6 +264,19 @@ describe("GrimmoryCFIResolver", function()
 
             assert.are.equal(
                 "epubcfi(/6/24!/4/2/6/3:3)",
+                actual
+            )
+        end)
+
+        it("converts xpointer referencing a target with no spaces between nodes", function()
+            local cfi_resolver = GrimmoryCFIResolver:new(fake_document)
+
+            local actual = cfi_resolver:xpointerToCFI(
+                "/body/DocFragment[12]/body/div/p[3]/span[2]/text().1"
+            )
+
+            assert.are.equal(
+                "epubcfi(/6/24!/4/2/8/4/1:1)",
                 actual
             )
         end)


### PR DESCRIPTION
in some cases there are problems with the way we generate CFIs here because the DOM is required to generate / interpret and xpointer and we are trying to simulate that

fixes #179
closes #180