### PR TITLE
fix: avoid android SIGABRT during sync

### DIFF
--- a/grimmory.koplugin/main.lua
+++ b/grimmory.koplugin/main.lua
@@ -444,6 +444,9 @@ function Grimmory:onGrimmorySync(verbose, book_path, refresh_book)
         -- network management causes Android devices to SIGABRT.
         if not self:isWifiConnected() then
             logger:err("Cannot sync without connectivity")
+            self.dialog_manager:toast(
+                _("Failed to Synchronize with Grimmory: No Connectivity")
+            )
             return
         end
 

--- a/grimmory.koplugin/main.lua
+++ b/grimmory.koplugin/main.lua
@@ -369,7 +369,7 @@ function Grimmory:isReadyToSync()
     return true
 end
 
-function Grimmory:isWifiConnected()
+function Grimmory:isConnected()
     local ok, result = pcall(function()
         return NetworkManager:isConnected()
     end)
@@ -440,6 +440,13 @@ function Grimmory:onGrimmorySync(verbose, book_path, refresh_book)
             return
         end
 
+        -- Run in the foreground, as something with background tasks and
+        -- network management causes Android devices to SIGABRT.
+        if not self:isConnected() then
+            logger:err("Cannot sync without connectivity")
+            return
+        end
+
         logger:info("Synchronizing to Grimmory")
 
         local terminated_early = false
@@ -486,11 +493,6 @@ function Grimmory:onGrimmorySync(verbose, book_path, refresh_book)
 
         local ok, result = run(
             function(progress_callback)
-                if not self:isWifiConnected() then
-                    logger:err("Cannot sync without connectivity")
-                    error("Cannot sync without connectivity")
-                end
-
                 if book_path then
                     self.synchronizer:synchronizeBook(book_path, refresh_book, progress_callback)
                 else

--- a/grimmory.koplugin/main.lua
+++ b/grimmory.koplugin/main.lua
@@ -369,7 +369,7 @@ function Grimmory:isReadyToSync()
     return true
 end
 
-function Grimmory:isConnected()
+function Grimmory:isWifiConnected()
     local ok, result = pcall(function()
         return NetworkManager:isConnected()
     end)
@@ -442,7 +442,7 @@ function Grimmory:onGrimmorySync(verbose, book_path, refresh_book)
 
         -- Run in the foreground, as something with background tasks and
         -- network management causes Android devices to SIGABRT.
-        if not self:isConnected() then
+        if not self:isWifiConnected() then
             logger:err("Cannot sync without connectivity")
             return
         end


### PR DESCRIPTION
calling `NetworkManager` from another subprocess seems to cause a SIGABRT in android koreader implementations (for some reason).  Instead of investigating that further, just avoid it.

fixes #185
fixes #186 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sync reliability by performing the connectivity check immediately before starting the sync, so it now fails fast when the device is offline.
  * Updated the sync flow to prevent delayed failures by removing the earlier in-progress connectivity handling, keeping the offline behavior consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->