### PR TITLE
chore: remove CFI migration

### DIFF
--- a/grimmory.koplugin/grimmory/migrations/4_book_event_cfi.sql
+++ b/grimmory.koplugin/grimmory/migrations/4_book_event_cfi.sql
@@ -1,1 +1,0 @@
-ALTER TABLE book_event ADD cfi TEXT NULL;


### PR DESCRIPTION
adding a CFI to the session events was a mistake, this removes the migration, too