### PR TITLE
fix: properly fail requests for get books on error

### DIFF
--- a/grimmory.koplugin/grimmory/grimmory_api.lua
+++ b/grimmory.koplugin/grimmory/grimmory_api.lua
@@ -472,7 +472,7 @@ function GrimmoryAPI:getBooks()
             -- If current_index is past the current batch
             local new_books_ok, new_books_batch, new_total_books = self:getBooksPage(page + 1)
 
-            if not new_books_ok or type(new_books_batch) ~= "table" then
+            if not new_books_ok then
                 logger:err("Unable to read books:", new_books_batch)
                 error("Unable to read books")
             end
@@ -481,6 +481,11 @@ function GrimmoryAPI:getBooks()
             batch_index = 0
             books_batch = new_books_batch
             total_books = new_total_books
+
+            if type(books_batch) ~= "table" or #books_batch == 0 then
+                -- Done iterating
+                return nil, book_index, total_books
+            end
         end
 
         batch_index = batch_index + 1

--- a/grimmory.koplugin/grimmory/grimmory_api.lua
+++ b/grimmory.koplugin/grimmory/grimmory_api.lua
@@ -458,31 +458,27 @@ function GrimmoryAPI:getBooks()
     if not books_ok then
         logger:err("Unable to read books:", books_batch)
         return function()
-            return nil, 0, 0
+            error("Unable to read books")
         end
     end
 
     return function ()
         if type(books_batch) ~= "table" or #books_batch == 0 then
+            -- Done iterating
             return nil, book_index, total_books
         end
 
         if batch_index >= #books_batch then
             -- If current_index is past the current batch
-            page = page + 1
-
-            local new_books_ok, new_books_batch, new_total_books = self:getBooksPage(page)
-            batch_index = 0
+            local new_books_ok, new_books_batch, new_total_books = self:getBooksPage(page + 1)
 
             if not new_books_ok or type(new_books_batch) ~= "table" then
                 logger:err("Unable to read books:", new_books_batch)
-
-                -- Set the books batch to empty so we basically stop iteration
-                books_batch = {}
-
-                return nil, book_index, total_books
+                error("Unable to read books")
             end
 
+            page = page + 1
+            batch_index = 0
             books_batch = new_books_batch
             total_books = new_total_books
         end


### PR DESCRIPTION
instead of returning a `nil` book on error, fail the entire request by raising an error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved book list loading behavior so retrieval failures are reported immediately instead of quietly terminating or returning partial results.
  * When fetching additional pages fails, the app now surfaces a clear error rather than stopping with inconsistent counters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->