### PR TITLE
fix: resolve _meta from local plugin path

### DIFF
--- a/grimmory.koplugin/grimmory/ota/self_updater.lua
+++ b/grimmory.koplugin/grimmory/ota/self_updater.lua
@@ -42,16 +42,6 @@ local function verifyDigest(path, digest)
     return true
 end
 
-local function getPluginPath()
-    local source = debug.getinfo(1, "S").source
-    local path = source:match("@(.*)/")
-    if not path or not path:match("%.koplugin$") then
-        path = DataStorage:getDataDir() .. "/plugins/grimmory.koplugin"
-    end
-
-    return path
-end
-
 local function findPluginInArchive(reader)
     for entry in reader:iterate() do
         if entry.mode == "file" then
@@ -126,7 +116,7 @@ end
 ---@field latest_known_version string | nil
 ---@field is_pending_restart boolean
 local GrimmorySelfUpdater = {
-    plugin_path = getPluginPath(),
+    plugin_path = PluginMetadata.getPluginPath(),
     release_asset_name = "%a+.koplugin.zip",
     release_cache_path = DataStorage:getDataDir() .. "/cache/grimmory"
 }

--- a/grimmory.koplugin/grimmory/plugin_metadata.lua
+++ b/grimmory.koplugin/grimmory/plugin_metadata.lua
@@ -1,30 +1,57 @@
-local _meta = require("_meta")
+local DataStorage = require("datastorage")
 
 ---@class GrimmoryPluginMetadata
-local PluginMetadata = {}
+local PluginMetadata = {
+    meta = nil,
+}
 
+function PluginMetadata.getPluginPath()
+    local source = debug.getinfo(1, "S").source
+    local path = source:match("@(.*%.koplugin)/")
+    if not path then
+        path = DataStorage:getDataDir() .. "/plugins/grimmory.koplugin"
+    end
+
+    return path
+end
+
+function PluginMetadata.getMeta()
+    if PluginMetadata.meta == nil then
+        local plugin_path = PluginMetadata.getPluginPath()
+        local meta_path = plugin_path .. "/_meta.lua"
+        PluginMetadata.meta = dofile(meta_path)
+    end
+
+    return PluginMetadata.meta or {}
+end
 
 ---@return boolean has_repository
 function PluginMetadata.hasRepository()
-    return type(_meta.repository) == "string"
+    local meta = PluginMetadata.getMeta()
+
+    return type(meta.repository) == "string"
 end
 
 ---@return string version
 function PluginMetadata.getVersion()
-    if type(_meta.version) ~= "string" then
+    local meta = PluginMetadata.getMeta()
+
+    if type(meta.version) ~= "string" then
         return "0.0.0-snapshot"
     end
 
-    return _meta.version
+    return meta.version
 end
 
 ---@return string repository
 function PluginMetadata.getRepository()
-    if type(_meta.repository) ~= "string" then
+    local meta = PluginMetadata.getMeta()
+
+    if type(meta.repository) ~= "string" then
         return "unknown repository"
     end
 
-    return _meta.repository
+    return meta.repository
 end
 
 return PluginMetadata

--- a/grimmory.koplugin/grimmory/plugin_metadata.lua
+++ b/grimmory.koplugin/grimmory/plugin_metadata.lua
@@ -1,5 +1,9 @@
 local DataStorage = require("datastorage")
 
+local GrimmoryLogger = require("grimmory/logger")
+
+local logger = GrimmoryLogger:new()
+
 ---@class GrimmoryPluginMetadata
 local PluginMetadata = {
     meta = nil,
@@ -19,7 +23,15 @@ function PluginMetadata.getMeta()
     if PluginMetadata.meta == nil then
         local plugin_path = PluginMetadata.getPluginPath()
         local meta_path = plugin_path .. "/_meta.lua"
-        PluginMetadata.meta = dofile(meta_path)
+
+        local load_ok, meta = pcall(dofile, meta_path)
+
+        if load_ok and type(meta) == "table" then
+            PluginMetadata.meta = meta
+        else
+            logger:err("Failed to load meta:", meta or "Unknown error")
+            PluginMetadata.meta = false
+        end
     end
 
     return PluginMetadata.meta or {}

--- a/spec/grimmory/plugin_metadata_spec.lua
+++ b/spec/grimmory/plugin_metadata_spec.lua
@@ -1,33 +1,36 @@
 package.path = "grimmory.koplugin/?.lua;" .. package.path
 
-local fake_package_meta = {
-
-}
-
-package.preload["_meta"] = function()
-    return fake_package_meta
+package.preload["gettext"] = function()
+    return function(text)
+        return text
+    end
 end
 
-package.preload["cache"] = function()
+package.preload["datastorage"] = function()
     return {
-        new = function()
-            local cache = {}
 
-            return {
-                get = function(key)
-                    return cache[key]
-                end,
-                insert = function(key, value)
-                    cache[key] = value
-                end
-            }
-        end,
     }
 end
+
+local fake_package_meta = {}
 
 local GrimmoryPluginMetadata = require("grimmory/plugin_metadata")
 
 describe("GrimmoryPluginMetadata", function()
+    local original_get_meta = nil
+
+    before_each(function()
+        original_get_meta = GrimmoryPluginMetadata.getMeta
+
+        GrimmoryPluginMetadata.getMeta = function()
+            return fake_package_meta
+        end
+    end)
+
+    after_each(function()
+        GrimmoryPluginMetadata.getMeta = original_get_meta
+    end)
+
     describe("hasRepository", function()
         it("returns false when repository field is missing", function()
             assert.are.equal(GrimmoryPluginMetadata:hasRepository(), false)

--- a/spec/grimmory/plugin_metadata_spec.lua
+++ b/spec/grimmory/plugin_metadata_spec.lua
@@ -1,5 +1,19 @@
 package.path = "grimmory.koplugin/?.lua;" .. package.path
 
+local fake_logger = {
+    err = spy.new(function() end),
+    info = spy.new(function() end),
+    dbg = spy.new(function() end),
+}
+
+package.preload["grimmory/logger"] = function()
+    return {
+        new = function()
+            return fake_logger
+        end
+    }
+end
+
 package.preload["gettext"] = function()
     return function(text)
         return text


### PR DESCRIPTION
when we require the `_meta` directly, other plugins can negatively interact with our resolution of the file.  instead, we should fetch the `_meta.lua` from the plugin path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved plugin update handling by loading plugin details dynamically at runtime.

* **Bug Fixes**
  * Made plugin path detection more reliable, with a fallback when the primary location isn’t available.
  * Improved handling when plugin metadata is missing or unavailable, helping avoid update-related failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->