### PR TITLE
fix: resolve plugin path using plugin loader if required

### DIFF
--- a/grimmory.koplugin/grimmory/plugin_metadata.lua
+++ b/grimmory.koplugin/grimmory/plugin_metadata.lua
@@ -1,22 +1,50 @@
 local DataStorage = require("datastorage")
+local PluginLoader = require("pluginloader")
+local util = require("util")
 
 local GrimmoryLogger = require("grimmory/logger")
 
 local logger = GrimmoryLogger:new()
 
+local function get_plugin_path()
+    -- First attempt searching for our plugin via the `debug`
+    -- utility - ask koreader for the "S" (source) and find
+    -- where in that value the koplugin lives
+    local source = debug.getinfo(1, "S").source
+    local path = source:match("@(.*%.koplugin)/")
+    if path and util.directoryExists(path) then
+        return path
+    end
+
+    -- If for some reason the debug.getinfo won't get us our plugin
+    -- path, we need to fall back to the plugin loader.  This is because
+    -- in some cases (like with the MultiUser plugin) our data dir may
+    -- not actually have our plugin!
+    local all_plugins = PluginLoader._discover()
+
+    for _, plugin in ipairs(all_plugins) do
+        if plugin.name == "grimmory.koplugin" then
+            return plugin.path
+        end
+    end
+
+    -- Fall back to DataStorage:getDataDir()`
+    return DataStorage:getDataDir() .. "/plugins/grimmory.koplugin"
+end
+
 ---@class GrimmoryPluginMetadata
 local PluginMetadata = {
+    plugin_path = nil,
     meta = nil,
 }
 
 function PluginMetadata.getPluginPath()
-    local source = debug.getinfo(1, "S").source
-    local path = source:match("@(.*%.koplugin)/")
-    if not path then
-        path = DataStorage:getDataDir() .. "/plugins/grimmory.koplugin"
+    if PluginMetadata.plugin_path == nil then
+        PluginMetadata.plugin_path = get_plugin_path()
+        logger:dbg("Resolved plugin path:", PluginMetadata.plugin_path)
     end
 
-    return path
+    return PluginMetadata.plugin_path
 end
 
 function PluginMetadata.getMeta()

--- a/grimmory.koplugin/grimmory/repository.lua
+++ b/grimmory.koplugin/grimmory/repository.lua
@@ -3,20 +3,11 @@ local DataStorage = require("datastorage")
 local util = require("util")
 
 local GrimmoryLogger = require("grimmory/logger")
+local PluginMetadata = require("grimmory/plugin_metadata")
 
 local logger = GrimmoryLogger:new()
 
 local SESSION_COLLAPSE_THRESHOLD = 180.0
-
-local function get_plugin_path()
-    local source = debug.getinfo(1, "S").source
-    local path = source:match("@(.*)/")
-    if not path or not path:match("%.koplugin$") then
-        path = DataStorage:getDataDir() .. "/plugins/grimmory.koplugin"
-    end
-
-    return path
-end
 
 ---@generic T
 ---@param database_path string
@@ -96,7 +87,7 @@ end
 ---@field migrations_path string
 ---@field database_path string
 local GrimmoryLocalRepository = {
-    migrations_path = get_plugin_path() .. "/grimmory/migrations/",
+    migrations_path = PluginMetadata:getPluginPath() .. "/grimmory/migrations/",
     database_path =  DataStorage:getSettingsDir() .. "/grimmory.sqlite3",
 }
 
@@ -147,6 +138,7 @@ function GrimmoryLocalRepository:runMigrations()
 end
 
 function GrimmoryLocalRepository:init()
+    logger:dbg("Running migrations")
     self:runMigrations()
 end
 

--- a/spec/grimmory/plugin_metadata_spec.lua
+++ b/spec/grimmory/plugin_metadata_spec.lua
@@ -20,6 +20,12 @@ package.preload["gettext"] = function()
     end
 end
 
+package.preload["pluginloader"] = function()
+    return {
+        _discover = function() return {} end
+    }
+end
+
 package.preload["datastorage"] = function()
     return {
 


### PR DESCRIPTION
there are cases where we have to use the plugin loader - such as with the multiuser plugin - to properly find the location of our plugin path

fixes #178

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of the Grimmory plugin location across supported installations.
  - Added fallback handling when the plugin directory cannot be identified directly.
  - Improved reliability of repository migration startup.
- **Performance**
  - Cached the resolved plugin location to avoid repeated path detection.
- **Tests**
  - Added coverage for environments where plugin discovery returns no results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->