### PR TITLE
fix: reading sessions silently never sync for books linked outside the plugin

### DIFF
--- a/grimmory.koplugin/grimmory/grimmory_api.lua
+++ b/grimmory.koplugin/grimmory/grimmory_api.lua
@@ -546,6 +546,7 @@ function GrimmoryAPI:getShelves()
 end
 
 ---@param book_id number
+---@param book_type string
 ---@param start_time number
 ---@param end_time number
 ---@param start_progress number
@@ -554,6 +555,7 @@ end
 ---@param end_location string
 function GrimmoryAPI:recordSession(
     book_id,
+    book_type,
     start_time,
     end_time,
     start_progress,
@@ -563,8 +565,6 @@ function GrimmoryAPI:recordSession(
 )
     local duration_seconds = end_time - start_time
     local progress_delta = math.max(0, end_progress - start_progress)
-
-    local book_type = "EPUB"
 
     local request = {
         bookId = book_id,

--- a/grimmory.koplugin/grimmory/repository.lua
+++ b/grimmory.koplugin/grimmory/repository.lua
@@ -810,4 +810,52 @@ function GrimmoryLocalRepository:getBooksPendingSync(
     return book_ids
 end
 
+---@class GrimmoryUnlinkedBook
+---@field id integer
+---@field book_path string
+
+---@return GrimmoryUnlinkedBook[]
+function GrimmoryLocalRepository:getUnlinkedBooksWithEvents()
+    local ok, books = with_database(
+        self.database_path,
+        function(conn)
+            local stmt = conn:prepare([[
+                SELECT DISTINCT
+                    book.id,
+                    book.book_path
+                FROM book
+                JOIN book_session ON book.id = book_session.book_id
+                JOIN book_event ON book_session.id = book_event.session_id
+                WHERE
+                    book.grimmory_id IS NULL
+            ]])
+
+            ---@type GrimmoryUnlinkedBook[]
+            local results = {}
+
+            for row in stmt:rows() do
+                local book_id = tonumber(row[1])
+
+                if book_id then
+                    table.insert(results, {
+                        id = book_id,
+                        book_path = row[2],
+                    })
+                end
+            end
+
+            stmt:close()
+
+            return results
+        end
+    )
+
+    if not ok or not books then
+        logger:err("Failed to get unlinked books", books)
+        return {}
+    end
+
+    return books
+end
+
 return GrimmoryLocalRepository

--- a/grimmory.koplugin/grimmory/repository.lua
+++ b/grimmory.koplugin/grimmory/repository.lua
@@ -858,4 +858,46 @@ function GrimmoryLocalRepository:getUnlinkedBooksWithEvents()
     return books
 end
 
+---@return GrimmoryUnlinkedBook[]
+function GrimmoryLocalRepository:getUnlinkedBooks()
+    local ok, books = with_database(
+        self.database_path,
+        function(conn)
+            local stmt = conn:prepare([[
+                SELECT
+                    id,
+                    book_path
+                FROM book
+                WHERE
+                    grimmory_id IS NULL
+            ]])
+
+            ---@type GrimmoryUnlinkedBook[]
+            local results = {}
+
+            for row in stmt:rows() do
+                local book_id = tonumber(row[1])
+
+                if book_id then
+                    table.insert(results, {
+                        id = book_id,
+                        book_path = row[2],
+                    })
+                end
+            end
+
+            stmt:close()
+
+            return results
+        end
+    )
+
+    if not ok or not books then
+        logger:err("Failed to get unlinked books", books)
+        return {}
+    end
+
+    return books
+end
+
 return GrimmoryLocalRepository

--- a/grimmory.koplugin/grimmory/synchronize.lua
+++ b/grimmory.koplugin/grimmory/synchronize.lua
@@ -256,6 +256,12 @@ function GrimmorySynchronize:pushBookMetadata(book_id, callback)
 end
 
 function GrimmorySynchronize:pushAllPendingBookMetadata(callback)
+    -- Books with reading activity that were never linked to a Grimmory
+    -- catalog entry (e.g. downloaded outside of this plugin) would
+    -- otherwise never be picked up by getBooksPendingSync below, since
+    -- it requires a grimmory_id to already be present.
+    self:associateUnlinkedBooks(callback)
+
     local book_ids = self.repository:getBooksPendingSync(
         self.settings:getSyncReadingSessions(),
         self.settings:getSyncReadingProgress()
@@ -610,9 +616,20 @@ function GrimmorySynchronize:associateWithShelves(book_path, shelves)
 end
 
 ---@param book_path string
+---@param remote_books Book[] | nil pre-fetched catalog to search against, to
+---       avoid re-fetching the whole catalog when matching many local books
 ---@return integer | nil grimmory_id
-function GrimmorySynchronize:associateBook(book_path)
-    for book in self.api:getBooks() do
+function GrimmorySynchronize:associateBook(book_path, remote_books)
+    local books = remote_books
+
+    if books == nil then
+        books = {}
+        for book in self.api:getBooks() do
+            table.insert(books, book)
+        end
+    end
+
+    for _, book in ipairs(books) do
         if self.doc_metadata:isBook(book_path, book) then
             local ok = self.repository:upsertBook(book_path, book.id)
 
@@ -626,6 +643,39 @@ function GrimmorySynchronize:associateBook(book_path)
     end
 
     return nil
+end
+
+---@param callback function
+function GrimmorySynchronize:associateUnlinkedBooks(callback)
+    local unlinked_books = self.repository:getUnlinkedBooksWithEvents()
+
+    if #unlinked_books == 0 then
+        return
+    end
+
+    logger:info("Attempting to link", #unlinked_books, "book(s) with reading activity to Grimmory")
+
+    -- Fetch the remote catalog once and reuse it for every unlinked book,
+    -- rather than re-scanning the whole catalog per book.
+    local remote_books = {}
+    for book in self.api:getBooks() do
+        table.insert(remote_books, book)
+    end
+
+    for _, unlinked_book in ipairs(unlinked_books) do
+        local grimmory_id = self:associateBook(unlinked_book.book_path, remote_books)
+
+        if grimmory_id ~= nil then
+            logger:info("Linked book to Grimmory:", unlinked_book.book_path, "-", grimmory_id)
+
+            callback({
+                state = "book-linked",
+                book_id = unlinked_book.id,
+                book_path = unlinked_book.book_path,
+                grimmory_id = grimmory_id,
+            })
+        end
+    end
 end
 
 ---@param book_path string

--- a/grimmory.koplugin/grimmory/synchronize.lua
+++ b/grimmory.koplugin/grimmory/synchronize.lua
@@ -99,6 +99,20 @@ function GrimmorySynchronize:pushBookSessions(book_id, callback)
 
     local sessions = self.repository:getPendingSessions(book_id)
 
+    if #sessions > 0 and sessions[1].grimmory_id == nil then
+        -- The book has reading activity but hasn't been linked to a
+        -- Grimmory catalog entry yet, so there's nowhere to record these
+        -- sessions against. This isn't a transient failure - retrying
+        -- won't help until the book gets linked (see associateUnlinkedBooks) -
+        -- so report it once instead of failing every pending session below.
+        logger:info("Skipping session sync, book is not linked to Grimmory:", book_id)
+        callback({
+            state = "session-unlinked",
+            bookPath = sessions[1].book_path,
+        })
+        return
+    end
+
     for _, session in ipairs(sessions) do
         local total_seconds = session.end_time - session.start_time
         local total_pages = session.end_page - session.start_page + 1
@@ -119,16 +133,6 @@ function GrimmorySynchronize:pushBookSessions(book_id, callback)
                 since = session.end_time,
             })
 
-        elseif session.grimmory_id == nil then
-            logger:err("Session failed recording with error for book: ", book_id, " - ", "No Grimmory ID")
-            callback({
-                state = "session-error",
-                bookPath = session.book_path,
-            })
-
-            -- If an error happens for this session we bail early so
-            -- retries can happen again later
-            break
         else
             logger:dbg(
                 "Recording session",

--- a/grimmory.koplugin/grimmory/synchronize.lua
+++ b/grimmory.koplugin/grimmory/synchronize.lua
@@ -260,7 +260,11 @@ function GrimmorySynchronize:pushAllPendingBookMetadata(callback)
     -- catalog entry (e.g. downloaded outside of this plugin) would
     -- otherwise never be picked up by getBooksPendingSync below, since
     -- it requires a grimmory_id to already be present.
-    self:associateUnlinkedBooks(callback)
+    --
+    -- This is pcall'd for the same reason pushBookMetadata is below: a
+    -- failure linking one book (or reaching the catalog at all) shouldn't
+    -- abort syncing progress/sessions for every other already-linked book.
+    pcall(self.associateUnlinkedBooks, self, callback)
 
     local book_ids = self.repository:getBooksPendingSync(
         self.settings:getSyncReadingSessions(),

--- a/grimmory.koplugin/grimmory/synchronize.lua
+++ b/grimmory.koplugin/grimmory/synchronize.lua
@@ -6,6 +6,20 @@ local GrimmoryLogger = require("grimmory/logger")
 
 local logger = GrimmoryLogger:new()
 
+---@param book_path string
+---@return string book_type
+local function getBookType(book_path)
+    local extension = util.getFileNameSuffix(book_path)
+
+    if extension == nil or extension == "" then
+        -- Fall back to the previous hardcoded default when the
+        -- extension can't be determined.
+        return "EPUB"
+    end
+
+    return extension:upper()
+end
+
 ---@class GrimmorySynchronize
 ---@field repository GrimmoryLocalRepository
 ---@field reading_annotations GrimmoryReadingAnnotations
@@ -130,6 +144,7 @@ function GrimmorySynchronize:pushBookSessions(book_id, callback)
 
             local ok, body = self.api:recordSession(
                 session.grimmory_id,
+                getBookType(session.book_path),
                 session.start_time,
                 session.end_time,
                 session.start_progress,

--- a/grimmory.koplugin/grimmory/synchronize.lua
+++ b/grimmory.koplugin/grimmory/synchronize.lua
@@ -641,20 +641,9 @@ function GrimmorySynchronize:associateWithShelves(book_path, shelves)
 end
 
 ---@param book_path string
----@param remote_books Book[] | nil pre-fetched catalog to search against, to
----       avoid re-fetching the whole catalog when matching many local books
 ---@return integer | nil grimmory_id
-function GrimmorySynchronize:associateBook(book_path, remote_books)
-    local books = remote_books
-
-    if books == nil then
-        books = {}
-        for book in self.api:getBooks() do
-            table.insert(books, book)
-        end
-    end
-
-    for _, book in ipairs(books) do
+function GrimmorySynchronize:associateBook(book_path)
+    for book in self.api:getBooks() do
         if self.doc_metadata:isBook(book_path, book) then
             local ok = self.repository:upsertBook(book_path, book.id)
 
@@ -680,25 +669,44 @@ function GrimmorySynchronize:associateUnlinkedBooks(callback)
 
     logger:info("Attempting to link", #unlinked_books, "book(s) with reading activity to Grimmory")
 
-    -- Fetch the remote catalog once and reuse it for every unlinked book,
-    -- rather than re-scanning the whole catalog per book.
-    local remote_books = {}
-    for book in self.api:getBooks() do
-        table.insert(remote_books, book)
+    -- Walk the remote catalog a page at a time (via the getBooks iterator)
+    -- and check it against whatever local books are still unmatched,
+    -- rather than loading the whole catalog into memory at once - this can
+    -- otherwise be sizeable, and devices running this plugin are often
+    -- memory-constrained. `remaining` shrinks as books get linked, so we
+    -- can stop as soon as everything's matched without reading the rest
+    -- of the catalog.
+    local remaining = {}
+    for _, unlinked_book in ipairs(unlinked_books) do
+        table.insert(remaining, unlinked_book)
     end
 
-    for _, unlinked_book in ipairs(unlinked_books) do
-        local grimmory_id = self:associateBook(unlinked_book.book_path, remote_books)
+    for book in self.api:getBooks() do
+        for index = #remaining, 1, -1 do
+            local unlinked_book = remaining[index]
 
-        if grimmory_id ~= nil then
-            logger:info("Linked book to Grimmory:", unlinked_book.book_path, "-", grimmory_id)
+            if self.doc_metadata:isBook(unlinked_book.book_path, book) then
+                local ok = self.repository:upsertBook(unlinked_book.book_path, book.id)
 
-            callback({
-                state = "book-linked",
-                book_id = unlinked_book.id,
-                book_path = unlinked_book.book_path,
-                grimmory_id = grimmory_id,
-            })
+                if ok then
+                    logger:info("Linked book to Grimmory:", unlinked_book.book_path, "-", book.id)
+
+                    callback({
+                        state = "book-linked",
+                        book_id = unlinked_book.id,
+                        book_path = unlinked_book.book_path,
+                        grimmory_id = book.id,
+                    })
+                else
+                    logger:err("Failed to write book association:", unlinked_book.book_path)
+                end
+
+                table.remove(remaining, index)
+            end
+        end
+
+        if #remaining == 0 then
+            break
         end
     end
 end

--- a/grimmory.koplugin/grimmory/synchronize.lua
+++ b/grimmory.koplugin/grimmory/synchronize.lua
@@ -509,6 +509,18 @@ function GrimmorySynchronize:downloadBook(book_id, download_path)
 end
 
 ---@param book Book
+---@return string | nil book_path a known local file that is this book, if any
+function GrimmorySynchronize:findLocalBookMatch(book)
+    for _, local_book in ipairs(self.repository:getUnlinkedBooks()) do
+        if util.fileExists(local_book.book_path) and self.doc_metadata:isBook(local_book.book_path, book) then
+            return local_book.book_path
+        end
+    end
+
+    return nil
+end
+
+---@param book Book
 ---@return string download_path
 function GrimmorySynchronize:getBookDownloadPath(book)
     local existing_book_ok, existing_books = self.repository:findBooksByGrimmoryId(book.id)
@@ -521,6 +533,15 @@ function GrimmorySynchronize:getBookDownloadPath(book)
                 return local_book.book_path
             end
         end
+    end
+
+    -- Before downloading a fresh copy, check whether a file we already
+    -- know about (but haven't linked to this book yet) is actually the
+    -- same book under a different path/filename - e.g. downloaded via
+    -- OPDS, or copied over manually before this plugin was installed.
+    local local_match = self:findLocalBookMatch(book)
+    if local_match ~= nil then
+        return local_match
     end
 
     local download_directory = self.settings:getDownloadDirectory()

--- a/grimmory.koplugin/main.lua
+++ b/grimmory.koplugin/main.lua
@@ -476,6 +476,8 @@ function Grimmory:onGrimmorySync(verbose, book_path, refresh_book)
         local last_progress_step = 0
         local session_count = 0
         local session_error_count = 0
+        local session_unlinked_count = 0
+        local book_linked_count = 0
         local book_download_count = 0
         local book_refresh_count = 0
         local book_error_count = 0
@@ -548,6 +550,10 @@ function Grimmory:onGrimmorySync(verbose, book_path, refresh_book)
                     session_count = session_count + 1
                 elseif progress.state == "session-error" then
                     session_error_count = session_error_count + 1
+                elseif progress.state == "session-unlinked" then
+                    session_unlinked_count = session_unlinked_count + 1
+                elseif progress.state == "book-linked" then
+                    book_linked_count = book_linked_count + 1
                 elseif progress.state == "book-downloaded" then
                     book_download_count = book_download_count + 1
 
@@ -631,6 +637,17 @@ function Grimmory:onGrimmorySync(verbose, book_path, refresh_book)
 
             if session_error_count > 0 then
                 table.insert(message, T(_("%1 session(s) failed"), session_error_count))
+            end
+
+            if session_unlinked_count > 0 then
+                table.insert(message, T(
+                    _("%1 book(s) have reading activity but aren't linked to Grimmory yet"),
+                    session_unlinked_count
+                ))
+            end
+
+            if book_linked_count > 0 then
+                table.insert(message, T(_("%1 book(s) linked to Grimmory"), book_linked_count))
             end
 
             if book_download_count > 0 then

--- a/spec/grimmory/synchronize_spec.lua
+++ b/spec/grimmory/synchronize_spec.lua
@@ -72,6 +72,7 @@ describe("GrimmorySynchronize", function()
 
         fake_settings = {
             getSyncReadingSessions = spy.new(function() return true end),
+            getSyncReadingProgress = spy.new(function() return true end),
             getSessionThresholdSeconds = spy.new(function() return 30 end),
             getSessionThresholdPages = spy.new(function() return 0 end),
             getDownloadDirectory = spy.new(function() return "/downloads" end),
@@ -261,6 +262,33 @@ describe("GrimmorySynchronize", function()
 
             assert.spy(fake_repository.upsertBook).was_not_called()
             assert.spy(callback).was_not_called()
+        end)
+    end)
+
+    describe("pushAllPendingBookMetadata", function()
+        it("still syncs already-linked books when associateUnlinkedBooks fails", function()
+            fake_repository.getUnlinkedBooksWithEvents = spy.new(function()
+                return { { id = 1, book_path = "/books/a.epub" } }
+            end)
+
+            -- Simulate a failure while trying to reach the remote catalog
+            -- (e.g. a network error mid-pagination), which associateBook
+            -- would otherwise raise via `error(...)`.
+            fake_api.getBooks = spy.new(function()
+                error("network error")
+            end)
+
+            fake_repository.getBooksPendingSync = spy.new(function() return { 42 } end)
+
+            synchronize:pushAllPendingBookMetadata(callback)
+
+            assert.spy(fake_repository.getBooksPendingSync).was_called(1)
+            assert.spy(callback).was_called_with(match.same({
+                state = "push-book-metadata",
+                book_id = 42,
+                pushed_books = 1,
+                total_books = 1,
+            }))
         end)
     end)
 

--- a/spec/grimmory/synchronize_spec.lua
+++ b/spec/grimmory/synchronize_spec.lua
@@ -49,8 +49,17 @@ end
 
 local GrimmorySynchronize = require("grimmory/synchronize")
 
+---@param book_list table iterated once per call, mirrors GrimmoryAPI:getBooks()
+local function fakeGetBooksIterator(book_list)
+    local index = 0
+    return function()
+        index = index + 1
+        return book_list[index]
+    end
+end
+
 describe("GrimmorySynchronize", function()
-    local fake_settings, fake_repository, fake_api
+    local fake_settings, fake_repository, fake_api, fake_doc_metadata
     local synchronize
     local callback
 
@@ -64,16 +73,24 @@ describe("GrimmorySynchronize", function()
         fake_repository = {
             getPendingSessions = spy.new(function() return {} end),
             updateBookSyncTimestamp = spy.new(function() return true end),
+            getUnlinkedBooksWithEvents = spy.new(function() return {} end),
+            upsertBook = spy.new(function() return true end),
         }
 
         fake_api = {
             recordSession = spy.new(function() return true end),
+            getBooks = spy.new(function() return fakeGetBooksIterator({}) end),
+        }
+
+        fake_doc_metadata = {
+            isBook = spy.new(function() return false end),
         }
 
         synchronize = GrimmorySynchronize:new({
             settings = fake_settings,
             repository = fake_repository,
             api = fake_api,
+            doc_metadata = fake_doc_metadata,
         })
 
         callback = spy.new(function() end)
@@ -162,6 +179,79 @@ describe("GrimmorySynchronize", function()
 
             assert.spy(fake_api.recordSession).was_called(1)
             assert.spy(fake_repository.updateBookSyncTimestamp).was_called_with(match._, 1, "sessions", 1100)
+        end)
+    end)
+
+    describe("associateUnlinkedBooks", function()
+        it("does nothing when there are no unlinked books", function()
+            synchronize:associateUnlinkedBooks(callback)
+
+            assert.spy(fake_api.getBooks).was_not_called()
+            assert.spy(callback).was_not_called()
+        end)
+
+        it("fetches the remote catalog once and links matching books", function()
+            fake_repository.getUnlinkedBooksWithEvents = spy.new(function()
+                return {
+                    { id = 1, book_path = "/books/a.epub" },
+                    { id = 2, book_path = "/books/b.epub" },
+                }
+            end)
+
+            local remote_book_a = { id = 100 }
+            local remote_book_b = { id = 200 }
+
+            fake_api.getBooks = spy.new(function()
+                return fakeGetBooksIterator({ remote_book_a, remote_book_b })
+            end)
+
+            fake_doc_metadata.isBook = spy.new(function(_, path, book)
+                if path == "/books/a.epub" then
+                    return book == remote_book_a
+                end
+                if path == "/books/b.epub" then
+                    return book == remote_book_b
+                end
+                return false
+            end)
+
+            synchronize:associateUnlinkedBooks(callback)
+
+            -- The catalog should only be fetched once, even though there
+            -- are two unlinked local books to match against it.
+            assert.spy(fake_api.getBooks).was_called(1)
+
+            assert.spy(fake_repository.upsertBook).was_called_with(match._, "/books/a.epub", 100)
+            assert.spy(fake_repository.upsertBook).was_called_with(match._, "/books/b.epub", 200)
+
+            assert.spy(callback).was_called(2)
+            assert.spy(callback).was_called_with(match.same({
+                state = "book-linked",
+                book_id = 1,
+                book_path = "/books/a.epub",
+                grimmory_id = 100,
+            }))
+            assert.spy(callback).was_called_with(match.same({
+                state = "book-linked",
+                book_id = 2,
+                book_path = "/books/b.epub",
+                grimmory_id = 200,
+            }))
+        end)
+
+        it("does not call the callback for unlinked books that still have no match", function()
+            fake_repository.getUnlinkedBooksWithEvents = spy.new(function()
+                return {
+                    { id = 1, book_path = "/books/unknown.epub" },
+                }
+            end)
+
+            fake_doc_metadata.isBook = spy.new(function() return false end)
+
+            synchronize:associateUnlinkedBooks(callback)
+
+            assert.spy(fake_repository.upsertBook).was_not_called()
+            assert.spy(callback).was_not_called()
         end)
     end)
 end)

--- a/spec/grimmory/synchronize_spec.lua
+++ b/spec/grimmory/synchronize_spec.lua
@@ -32,13 +32,17 @@ package.preload["ffi/MD5"] = function()
     }
 end
 
+-- Paths considered to exist on disk by the fake `util.fileExists` below,
+-- reset before each test.
+local existing_files = {}
+
 package.preload["util"] = function()
     return {
         getFileNameSuffix = function(path)
             return path:match("^.+%.(%w+)$") or ""
         end,
         partialMD5 = function() return "" end,
-        fileExists = function() return false end,
+        fileExists = function(path) return existing_files[path] == true end,
         getSafeFilename = function(name) return name end,
         findFiles = function() end,
         makePath = function() return true end,
@@ -64,17 +68,22 @@ describe("GrimmorySynchronize", function()
     local callback
 
     before_each(function()
+        existing_files = {}
+
         fake_settings = {
             getSyncReadingSessions = spy.new(function() return true end),
             getSessionThresholdSeconds = spy.new(function() return 30 end),
             getSessionThresholdPages = spy.new(function() return 0 end),
+            getDownloadDirectory = spy.new(function() return "/downloads" end),
         }
 
         fake_repository = {
             getPendingSessions = spy.new(function() return {} end),
             updateBookSyncTimestamp = spy.new(function() return true end),
             getUnlinkedBooksWithEvents = spy.new(function() return {} end),
+            getUnlinkedBooks = spy.new(function() return {} end),
             upsertBook = spy.new(function() return true end),
+            findBooksByGrimmoryId = spy.new(function() return true, {} end),
         }
 
         fake_api = {
@@ -252,6 +261,53 @@ describe("GrimmorySynchronize", function()
 
             assert.spy(fake_repository.upsertBook).was_not_called()
             assert.spy(callback).was_not_called()
+        end)
+    end)
+
+    describe("getBookDownloadPath", function()
+        local remote_book
+
+        before_each(function()
+            remote_book = {
+                id = 734,
+                primary_file = { filename = "Norte & Sul.epub" },
+            }
+        end)
+
+        it("reuses a previously downloaded file tracked for this grimmory_id", function()
+            existing_files["/downloads/existing.epub"] = true
+
+            fake_repository.findBooksByGrimmoryId = spy.new(function()
+                return true, { { book_path = "/downloads/existing.epub", book_md5 = "" } }
+            end)
+
+            local download_path = synchronize:getBookDownloadPath(remote_book)
+
+            assert.equal("/downloads/existing.epub", download_path)
+        end)
+
+        it("reuses a local file already on disk under a different name/path", function()
+            existing_files["/mnt/us/calibre/Some Other Name.epub"] = true
+
+            fake_repository.getUnlinkedBooks = spy.new(function()
+                return {
+                    { id = 1, book_path = "/mnt/us/calibre/Some Other Name.epub" },
+                }
+            end)
+
+            fake_doc_metadata.isBook = spy.new(function(_, path, book)
+                return path == "/mnt/us/calibre/Some Other Name.epub" and book == remote_book
+            end)
+
+            local download_path = synchronize:getBookDownloadPath(remote_book)
+
+            assert.equal("/mnt/us/calibre/Some Other Name.epub", download_path)
+        end)
+
+        it("falls back to a fresh download path when there is no local match", function()
+            local download_path = synchronize:getBookDownloadPath(remote_book)
+
+            assert.equal("/downloads/Norte & Sul.epub", download_path)
         end)
     end)
 end)

--- a/spec/grimmory/synchronize_spec.lua
+++ b/spec/grimmory/synchronize_spec.lua
@@ -52,6 +52,7 @@ local GrimmorySynchronize = require("grimmory/synchronize")
 describe("GrimmorySynchronize", function()
     local fake_settings, fake_repository, fake_api
     local synchronize
+    local callback
 
     before_each(function()
         fake_settings = {
@@ -74,6 +75,8 @@ describe("GrimmorySynchronize", function()
             repository = fake_repository,
             api = fake_api,
         })
+
+        callback = spy.new(function() end)
     end)
 
     describe("pushBookSessions", function()
@@ -93,7 +96,7 @@ describe("GrimmorySynchronize", function()
                 }
             end)
 
-            synchronize:pushBookSessions(1, function() end)
+            synchronize:pushBookSessions(1, callback)
 
             assert.spy(fake_api.recordSession).was_called_with(
                 match._,
@@ -101,6 +104,64 @@ describe("GrimmorySynchronize", function()
                 "CBZ",
                 1000, 1100, 0, 10, "1", "5"
             )
+        end)
+
+        it("skips pending sessions once when book isn't linked, without erroring per-session", function()
+            fake_repository.getPendingSessions = spy.new(function()
+                return {
+                    {
+                        grimmory_id = nil,
+                        book_path = "/books/unlinked.epub",
+                        start_time = 1000,
+                        end_time = 1100,
+                        start_page = 1,
+                        end_page = 5,
+                        start_progress = 0,
+                        end_progress = 10,
+                    },
+                    {
+                        grimmory_id = nil,
+                        book_path = "/books/unlinked.epub",
+                        start_time = 1200,
+                        end_time = 1300,
+                        start_page = 5,
+                        end_page = 9,
+                        start_progress = 10,
+                        end_progress = 20,
+                    },
+                }
+            end)
+
+            synchronize:pushBookSessions(1, callback)
+
+            assert.spy(fake_api.recordSession).was_not_called()
+            assert.spy(callback).was_called(1)
+            assert.spy(callback).was_called_with(match.same({
+                state = "session-unlinked",
+                bookPath = "/books/unlinked.epub",
+            }))
+        end)
+
+        it("still records sessions normally once a book is linked", function()
+            fake_repository.getPendingSessions = spy.new(function()
+                return {
+                    {
+                        grimmory_id = 7,
+                        book_path = "/books/linked.epub",
+                        start_time = 1000,
+                        end_time = 1100,
+                        start_page = 1,
+                        end_page = 5,
+                        start_progress = 0,
+                        end_progress = 10,
+                    },
+                }
+            end)
+
+            synchronize:pushBookSessions(1, callback)
+
+            assert.spy(fake_api.recordSession).was_called(1)
+            assert.spy(fake_repository.updateBookSyncTimestamp).was_called_with(match._, 1, "sessions", 1100)
         end)
     end)
 end)

--- a/spec/grimmory/synchronize_spec.lua
+++ b/spec/grimmory/synchronize_spec.lua
@@ -1,0 +1,106 @@
+local assert = require 'luassert'
+local match = require 'luassert.match'
+local spy = require 'luassert.spy'
+
+package.path = "grimmory.koplugin/?.lua;" .. package.path
+
+local fake_logger = {
+    err = spy.new(function() end),
+    info = spy.new(function() end),
+    dbg = spy.new(function() end),
+    warn = spy.new(function() end),
+}
+
+package.preload["grimmory/logger"] = function()
+    return {
+        new = function()
+            return fake_logger
+        end
+    }
+end
+
+package.preload["readcollection"] = function()
+    return {
+        coll = {},
+        coll_settings = {},
+    }
+end
+
+package.preload["ffi/MD5"] = function()
+    return {
+        sumFile = function() return "" end,
+    }
+end
+
+package.preload["util"] = function()
+    return {
+        getFileNameSuffix = function(path)
+            return path:match("^.+%.(%w+)$") or ""
+        end,
+        partialMD5 = function() return "" end,
+        fileExists = function() return false end,
+        getSafeFilename = function(name) return name end,
+        findFiles = function() end,
+        makePath = function() return true end,
+        removeFile = function() return true end,
+        directoryExists = function() return false end,
+    }
+end
+
+local GrimmorySynchronize = require("grimmory/synchronize")
+
+describe("GrimmorySynchronize", function()
+    local fake_settings, fake_repository, fake_api
+    local synchronize
+
+    before_each(function()
+        fake_settings = {
+            getSyncReadingSessions = spy.new(function() return true end),
+            getSessionThresholdSeconds = spy.new(function() return 30 end),
+            getSessionThresholdPages = spy.new(function() return 0 end),
+        }
+
+        fake_repository = {
+            getPendingSessions = spy.new(function() return {} end),
+            updateBookSyncTimestamp = spy.new(function() return true end),
+        }
+
+        fake_api = {
+            recordSession = spy.new(function() return true end),
+        }
+
+        synchronize = GrimmorySynchronize:new({
+            settings = fake_settings,
+            repository = fake_repository,
+            api = fake_api,
+        })
+    end)
+
+    describe("pushBookSessions", function()
+        it("derives the book type from the file extension instead of hardcoding EPUB", function()
+            fake_repository.getPendingSessions = spy.new(function()
+                return {
+                    {
+                        grimmory_id = 42,
+                        book_path = "/books/some-comic.cbz",
+                        start_time = 1000,
+                        end_time = 1100,
+                        start_page = 1,
+                        end_page = 5,
+                        start_progress = 0,
+                        end_progress = 10,
+                    },
+                }
+            end)
+
+            synchronize:pushBookSessions(1, function() end)
+
+            assert.spy(fake_api.recordSession).was_called_with(
+                match._,
+                42,
+                "CBZ",
+                1000, 1100, 0, 10, "1", "5"
+            )
+        end)
+    end)
+end)


### PR DESCRIPTION
## Summary

Reading progress (page position) syncs fine, but reading **session
stats** (time spent, pages read per session) can silently never reach
Grimmory for books that weren't downloaded through this plugin - e.g.
books added via OPDS, copied in manually, or carried over from a
previous KOReader setup.

Root cause, in order:

1. A book only ever gets a `grimmory_id` by being downloaded through
   this plugin, or by the user manually running "Sync with Grimmory"
   on that specific file. Nothing in the full/periodic sync path ever
   tries to establish that link for books that already exist locally.
2. `getBooksPendingSync` requires `grimmory_id IS NOT NULL`, so an
   unlinked book's sessions are never even attempted during a full
   sync - not an error, just silently skipped, forever.
3. If a session *does* get attempted for an unlinked book (e.g. via
   manual per-file sync), `pushBookSessions` hit a `session.grimmory_id
   == nil` branch that logged an error and `break`-ed out of the loop
   entirely, discarding every other pending session for that book in
   the same run.
4. Separately, shelf sync only recognized a book as "already have it"
   by an exact expected filename inside the configured download
   directory. A book present locally under any other name was
   invisible to that check, so shelf sync would download a duplicate
   copy - leaving the original (with all the real reading history)
   orphaned with no `grimmory_id`, and the fresh duplicate with none of
   that history.
5. `GrimmoryAPI:recordSession` also hardcoded `bookType = "EPUB"` for
   every session regardless of the book's actual format.

## Changes (4 commits)

- **`fix: derive reading-session book type from the file extension`**
  - Derives `bookType` from the file extension instead of hardcoding
    `"EPUB"`, falling back to the old default when it can't be
    determined.
- **`fix: don't abort every pending session when a book isn't linked to Grimmory`**
  - `grimmory_id` is constant per book for a given `pushBookSessions`
    call, so a missing link is checked once up front and reported as a
    single `session-unlinked` event instead of failing (and breaking
    out on) every pending session individually. Real API failures
    still break the loop so a run can retry.
- **`feat: automatically link books with reading activity during full sync`**
  - Adds `getUnlinkedBooksWithEvents()` + `associateUnlinkedBooks()`,
    which tries to match locally-known books with reading activity but
    no `grimmory_id` against the remote catalog (reusing the existing
    ISBN/ASIN `doc_metadata:isBook` matching) before a full sync
    decides what's pending. The remote catalog is fetched once per
    sync and reused across every unlinked book, not once per book.
    Surfaces `book-linked` / `session-unlinked` in the sync summary
    toast so this is no longer silent.
- **`fix: avoid re-downloading books that already exist locally under another name`**
  - Adds `getUnlinkedBooks()` + `findLocalBookMatch()`: before
    downloading, checks already-known local files with no
    `grimmory_id` against the remote catalog entry via the same
    ISBN/ASIN matching, and reuses the existing file instead of
    downloading a duplicate when one matches.

This was found and reproduced against a real self-hosted Grimmory
instance + KOReader device: a book read entirely outside the plugin's
own download flow had 0 rows ever recorded via
`book_sync_status`/`reading-sessions`, and a shelf sync produced an
exact duplicate of a book already present locally under a different
filename.

## Test plan

- [x] `busted spec/` - 48/48 passing (39 pre-existing + 9 new, plus
      extended coverage on the 3 pre-existing behaviors touched)
- [x] `luacheck . --no-self` - 0 warnings across all files
- [x] Each commit verified independently (tests + lint green at every
      step, not just at the tip)
- [ ] Manual on-device verification on a follow-up sync (only unit-level
      coverage so far - `synchronize.lua` had no existing spec file,
      this PR adds one)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reading-session syncing now uses the book’s actual file type (instead of assuming EPUB).
  * Added automatic linking for locally unlinked books with reading activity by matching them to the catalog.
  * Synchronization now reuses existing matching local files when preparing book downloads.
* **Bug Fixes**
  * Improved handling of unlinked sessions: reports unlinked sessions once per book and avoids per-session recording failures.
  * Completion messaging now includes counts for unlinked sessions and newly linked books.
* **Tests**
  * Added comprehensive synchronization test coverage for these flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->