### PR TITLE
fix: count only non-empty text nodes for xpointer text() index

### DIFF
--- a/grimmory.koplugin/grimmory/cfi_resolver.lua
+++ b/grimmory.koplugin/grimmory/cfi_resolver.lua
@@ -269,7 +269,11 @@ local function get_child(tokens, child_index)
         node_counter = node_counter + 1
 
         if token.type == "text" then
-            match_counters["text()"] = (match_counters["text()"] or 0) + 1
+            -- Empty strings get no text node in crengine, so text() indexes
+            -- only the non-empty ones.  node_counter still counts every slot.
+            if token.text ~= "" then
+                match_counters["text()"] = (match_counters["text()"] or 0) + 1
+            end
         elseif token.type == "tag" then
             match_counters[token.text] = (match_counters[token.text] or 0) + 1
         end

--- a/spec/grimmory/cfi_resolver_spec.lua
+++ b/spec/grimmory/cfi_resolver_spec.lua
@@ -200,6 +200,40 @@ describe("GrimmoryCFIResolver", function()
                 actual
             )
         end)
+
+        it("skips empty text nodes when indexing text()", function()
+            fake_document.getDocumentFileContent = spy.new(function() return [[CDATA
+<html><head></head><body><div><p><span epub:type="pagebreak"/>first real<span/>second real</p></div></body></html>
+            ]] end)
+
+            local cfi_resolver = GrimmoryCFIResolver:new(fake_document)
+
+            local actual = cfi_resolver:cfiToXpointer(
+                "epubcfi(/6/24!/4/2/2/5)"
+            )
+
+            assert.are.equal(
+                "/body/DocFragment[12]/body/div/p/text()[2]",
+                actual
+            )
+        end)
+
+        it("indexes the only non-empty text node as the first", function()
+            fake_document.getDocumentFileContent = spy.new(function() return [[CDATA
+<html><head></head><body><div><p><span epub:type="pagebreak"/><span/>only real</p></div></body></html>
+            ]] end)
+
+            local cfi_resolver = GrimmoryCFIResolver:new(fake_document)
+
+            local actual = cfi_resolver:cfiToXpointer(
+                "epubcfi(/6/24!/4/2/2/5)"
+            )
+
+            assert.are.equal(
+                "/body/DocFragment[12]/body/div/p/text()",
+                actual
+            )
+        end)
     end)
 
     describe("xpointerToCFI", function()


### PR DESCRIPTION
crengine has no text node for an empty string, so counting the slots we synthesise for CFI positions overcounts. For `<p><span epub:type="pagebreak"/>I hated being in a fight...` the paragraph's leading text slot is empty, so we emit text()[2] where the document has text()[1]. The xpointer resolves to nothing, table.sort throws in updateAnnotations, and since that runs on document open the book won't open at all. The new specs are verified failing on main.

Worth noting this only covers genuinely empty slots. onText in lvtinydom.cpp also drops whitespace-only text when it's the first child of a non-pre block (IsEmptySpace), so a pretty-printed `<p>\n  <span/>text` will still come out one off. This seemed beyond the scope of my known, production ebook issue though so I've left it out of this PR

AI-assisted (Claude). Found via a real failure on a Kindle Oasis 3 where 4 of 24 highlights in one ePub made the book unopenable.